### PR TITLE
重构proxyBuffer

### DIFF
--- a/source/src/main/java/io/mycat/mycat2/MycatSessionManager.java
+++ b/source/src/main/java/io/mycat/mycat2/MycatSessionManager.java
@@ -38,7 +38,8 @@ public class MycatSessionManager implements SessionManager<MySQLSession> {
 		session.setCurNIOHandler(MySQLClientAuthHandler.INSTANCE);
 		// 默认为透传命令模式
 		session.curSQLCommand = DirectPassthrouhCmd.INSTANCE;
-
+		// 设置 前端拥有
+		session.frontBuffer.changeOwner(true);
 		// 向MySQL Client发送认证报文
 		session.sendAuthPackge();
 		session.setSessionManager(this);

--- a/source/src/main/java/io/mycat/mycat2/beans/MySQLPackageInf.java
+++ b/source/src/main/java/io/mycat/mycat2/beans/MySQLPackageInf.java
@@ -5,7 +5,7 @@ package io.mycat.mycat2.beans;
  *
  */
 public class MySQLPackageInf {
-public int pkgType;
+public byte pkgType;
 public boolean crossBuffer;
 public int startPos;
 public int endPos;
@@ -14,4 +14,9 @@ public int pkgLength;
  * 还有多少字节才结束，仅对跨多个Buffer的MySQL报文有意义（crossBuffer=true)
  */
 public int remainsBytes;
+@Override
+public String toString() {
+	return "MySQLPackageInf [pkgType=" + pkgType + ", crossBuffer=" + crossBuffer + ", startPos=" + startPos
+			+ ", endPos=" + endPos + ", pkgLength=" + pkgLength + ", remainsBytes=" + remainsBytes + "]";
+}
 }

--- a/source/src/main/java/io/mycat/mycat2/cmds/DirectPassthrouhCmd.java
+++ b/source/src/main/java/io/mycat/mycat2/cmds/DirectPassthrouhCmd.java
@@ -2,10 +2,17 @@ package io.mycat.mycat2.cmds;
 
 import java.io.IOException;
 import java.nio.channels.SocketChannel;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.mycat.mycat2.MySQLSession;
 import io.mycat.mycat2.SQLCommand;
 import io.mycat.mycat2.beans.MySQLPackageInf;
+import io.mycat.mysql.packet.MySQLPacket;
 import io.mycat.proxy.ProxyBuffer;
 
 /**
@@ -15,31 +22,138 @@ import io.mycat.proxy.ProxyBuffer;
  *
  */
 public class DirectPassthrouhCmd implements SQLCommand {
-
-	public static final DirectPassthrouhCmd INSTANCE=new DirectPassthrouhCmd();
+	
+	private static final Logger logger = LoggerFactory.getLogger(DirectPassthrouhCmd.class);
+	
+	public static final DirectPassthrouhCmd INSTANCE = new DirectPassthrouhCmd();
+	
+	//********** 临时处理,等待与KK 代码合并
+	private static final Map<Byte,Integer> finishPackage = new HashMap<>();
+	
+	private Map<Byte,Integer> curfinishPackage = new HashMap<>();
+	
+	static{
+		finishPackage.put(MySQLPacket.OK_PACKET, 1);
+		finishPackage.put(MySQLPacket.ERROR_PACKET, 1);
+		finishPackage.put(MySQLPacket.EOF_PACKET, 2);
+	}
+	//********** 临时处理,等待与KK 代码合并
+	
 	@Override
 	public boolean procssSQL(MySQLSession session, boolean backresReceived) throws IOException {
-
+		if(backresReceived){
+			return backendProcessor(session,session.curFrontMSQLPackgInf,session.frontChannel,session.frontBuffer);
+		}else{
+			return frontProcessor(session,backresReceived);
+		}
+	}
+	
+	/**
+	 * 前端报文处理
+	 * @param session
+	 * @return
+	 * @throws IOException
+	 */
+	private boolean frontProcessor(MySQLSession session, boolean backresReceived) throws IOException{
+		curfinishPackage.putAll(finishPackage);
 		ProxyBuffer curBuffer = session.frontBuffer;
 		SocketChannel curChannel = session.backendChannel;
-		if (backresReceived) {// 收到后端发来的报文
-
-			curBuffer = session.frontBuffer;
-			curChannel = session.frontChannel;
+		// 切换 buffer  读写状态
+		curBuffer.flip();
+		// 改变 owner
+		curBuffer.changeOwner(false);
+		// 没有读取,直接透传时,需要指定 透传的数据 截止位置
+		curBuffer.readIndex = curBuffer.writeIndex;
+		//当前是前端报文处理器,如果是后端报文处理器调用,不切换Owner
+		session.writeToChannel(curBuffer, curChannel);
+		return false;
+	}
+	
+	/**
+	 * 后端报文处理
+	 * @param session
+	 * @return
+	 * @throws IOException
+	 */
+	private boolean backendProcessor(MySQLSession session,MySQLPackageInf curMSQLPackgInf,
+			SocketChannel curChannel,ProxyBuffer curBuffer)throws IOException{
+		
+		if(!session.readFromChannel(session.frontBuffer, session.backendChannel)){
+			return false;
 		}
 
-		// 直接透传报文
-		curBuffer.changeOwner(!curBuffer.frontUsing());
+		boolean isallfinish = false;
+		boolean isContinue = true;
+		while(isContinue){
+			switch(session.resolveMySQLPackage(curBuffer, curMSQLPackgInf,true)){
+				case Full:						
+					Integer count = curfinishPackage.get(curMSQLPackgInf.pkgType);
+					if(count!=null){
+						if(--count==0){
+							isallfinish = true;
+							curfinishPackage.clear();
+						}
+						curfinishPackage.put(curMSQLPackgInf.pkgType, count);
+					}
+					if(curBuffer.readIndex == curBuffer.writeIndex){
+						isContinue = false;
+					}else{
+						isContinue = true;
+					}
+					break;
+				case LongHalfPacket:			
+					if(curMSQLPackgInf.crossBuffer){
+						//发生过透传的半包,往往包的长度超过了buffer 的长度.
+						logger.debug(" readed crossBuffer LongHalfPacket ,curMSQLPackgInf is {}", curMSQLPackgInf);
+					}else if(!isfinishPackage(curMSQLPackgInf)){
+						//不需要整包解析的长半包透传. result set  .这种半包直接透传
+						curMSQLPackgInf.crossBuffer=true;
+						curBuffer.readIndex = curMSQLPackgInf.endPos;
+						curMSQLPackgInf.remainsBytes = curMSQLPackgInf.pkgLength-(curMSQLPackgInf.endPos - curMSQLPackgInf.startPos);
+						logger.debug(" readed LongHalfPacket ,curMSQLPackgInf is {}", curMSQLPackgInf);
+						logger.debug(" curBuffer {}", curBuffer);
+					}else{
+						// 读取到了EOF/OK/ERROR 类型长半包  是需要保证是整包的.
+						logger.debug(" readed finished LongHalfPacket ,curMSQLPackgInf is {}", curMSQLPackgInf);
+						// TODO  保证整包的机制
+					}
+					isContinue = false;
+					break;
+				case ShortHalfPacket:
+					logger.debug(" readed ShortHalfPacket ,curMSQLPackgInf is {}", curMSQLPackgInf);
+					isContinue = false;
+					break;
+			}
+		};
+		
+		//切换buffer 读写状态
 		curBuffer.flip();
+		if(isallfinish){
+			curBuffer.changeOwner(true);
+		}
+		// 直接透传报文
 		session.writeToChannel(curBuffer, curChannel);
-		session.modifySelectKey();
+		/**
+		* 当前命令处理是否全部结束,全部结束时需要清理资源
+		*/
 		return false;
+	}
+	
+	private boolean isfinishPackage(MySQLPackageInf curMSQLPackgInf)throws IOException{
+		switch(curMSQLPackgInf.pkgType){
+		case MySQLPacket.OK_PACKET:
+		case MySQLPacket.ERROR_PACKET:
+		case MySQLPacket.EOF_PACKET:
+			return true;
+		default:
+			return false;
+		}
 	}
 
 	@Override
 	public void clearResouces(boolean sessionCLosed) {
-		// nothint to do
-
+		// TODO Auto-generated method stub
+		
 	}
 
 }

--- a/source/src/main/java/io/mycat/mycat2/cmds/QueryCmdProcessImpl.java
+++ b/source/src/main/java/io/mycat/mycat2/cmds/QueryCmdProcessImpl.java
@@ -54,7 +54,7 @@ public class QueryCmdProcessImpl implements SQLComandProcessInf {
 
 		byte[] sql = session.frontBuffer.getBytes(
 				session.curFrontMSQLPackgInf.startPos + MySQLPacket.packetHeaderSize + 1,
-				session.curFrontMSQLPackgInf.endPos - MySQLPacket.packetHeaderSize - 1);
+				session.curFrontMSQLPackgInf.pkgLength - MySQLPacket.packetHeaderSize - 1);
 		sqlParser.parse(sql, sqlContext);
 		if (sqlContext.hasAnnotation()) {
 			// 此处添加注解处理

--- a/source/src/main/java/io/mycat/mycat2/net/DefaultMycatSessionHandler.java
+++ b/source/src/main/java/io/mycat/mycat2/net/DefaultMycatSessionHandler.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.mycat.mycat2.MySQLSession;
+import io.mycat.mycat2.MySQLSession.CurrPacketType;
 import io.mycat.mycat2.beans.MySQLDataSource;
 import io.mycat.mycat2.cmds.QueryCmdProcessImpl;
 import io.mycat.mycat2.cmds.SQLComandProcessInf;
@@ -55,14 +56,12 @@ public class DefaultMycatSessionHandler implements FrontIOHandler<MySQLSession>,
 	public void onFrontRead(final MySQLSession session) throws IOException {
 		boolean readed = session.readFromChannel(session.frontBuffer, session.frontChannel);
 		ProxyBuffer buffer = session.frontBuffer;
-		if (readed == false) {
+		if (readed == false||
+				// 没有读到完整报文
+				CurrPacketType.Full != session.resolveMySQLPackage(buffer, session.curFrontMSQLPackgInf, false)) {
 			return;
 		}
-		if (session.resolveMySQLPackage(buffer, session.curFrontMSQLPackgInf, false) == false) {
-			// 没有读到完整报文
-			return;
-		}
-		if (session.curFrontMSQLPackgInf.endPos < buffer.getReadOptState().optLimit) {
+		if (session.curFrontMSQLPackgInf.endPos < buffer.writeIndex) {
 			logger.warn("front contains multi package ");
 		}
 		if (session.backendChannel == null) {
@@ -127,29 +126,10 @@ public class DefaultMycatSessionHandler implements FrontIOHandler<MySQLSession>,
 	}
 
 	public void onBackendRead(MySQLSession session) throws IOException {
-		boolean readed = session.readFromChannel(session.frontBuffer, session.backendChannel);
-		if (readed == false) {
-			return;
-		}
-
-		ProxyBuffer backendBuffer = session.frontBuffer;
-
-		if (session.resolveMySQLPackage(backendBuffer, session.curFrontMSQLPackgInf, false) == false && !session.curFrontMSQLPackgInf.crossBuffer) {
-			// 没有读到完整报文, 也不是挎包
-			return;
-		}
 
 		// 交给SQLComand去处理
 		if (session.curSQLCommand.procssSQL(session, true)) {
 			session.curSQLCommand.clearResouces(false);
-		}
-
-		// 检查当前的包是否需要进行特殊的处理
-		DefaultMycatSessionHandler handler = PKGMAP.get(session.curFrontMSQLPackgInf.pkgType);
-
-		if (null != handler) {
-			// 设置lodata的透传执行
-			session.setCurNIOHandler(handler);
 		}
 
 	}
@@ -200,7 +180,6 @@ public class DefaultMycatSessionHandler implements FrontIOHandler<MySQLSession>,
 	@Override
 	public void onFrontWrite(MySQLSession session) throws IOException {
 		session.writeToChannel(session.frontBuffer, session.frontChannel);
-
 	}
 
 	@Override

--- a/source/src/main/java/io/mycat/mycat2/net/LoadDataHandler.java
+++ b/source/src/main/java/io/mycat/mycat2/net/LoadDataHandler.java
@@ -42,7 +42,7 @@ public class LoadDataHandler extends DefaultMycatSessionHandler {
 		if (readed == false) {
 			return;
 		}
-		if (session.curFrontMSQLPackgInf.endPos < backendBuffer.getReadOptState().optLimit) {
+		if (session.curFrontMSQLPackgInf.endPos < backendBuffer.writeIndex) {
 			logger.warn("front contains multi package ");
 		}
 
@@ -91,7 +91,7 @@ public class LoadDataHandler extends DefaultMycatSessionHandler {
 			return true;
 		}
 		// 当前的buffer被写完之后，需要做清空处理
-		if (curBuffer.writeState.optPostion == curBuffer.getBuffer().position()) {
+		if (curBuffer.writeIndex == curBuffer.getBuffer().position()) {
 			curBuffer.reset();
 		}
 
@@ -110,14 +110,14 @@ public class LoadDataHandler extends DefaultMycatSessionHandler {
 
 		// 如果数据的长度超过了，结束符的长度，可直接提取结束符
 		if (buffer.position() >= FLAGLENGTH) {
-			int opts = curBuffer.readState.optLimit;
+			int opts = curBuffer.readIndex;
 			buffer.position(opts - FLAGLENGTH);
 			buffer.get(overFlag, 0, FLAGLENGTH);
 			buffer.position(opts);
 		}
 		// 如果小于结束符，说明需要进行两个byte数组的合并
 		else {
-			int opts = curBuffer.readState.optLimit;
+			int opts = curBuffer.readIndex;
 			// 计算放入的位置
 			int moveSize = FLAGLENGTH - opts;
 			int index = 0;

--- a/source/src/main/java/io/mycat/mycat2/net/MySQLClientAuthHandler.java
+++ b/source/src/main/java/io/mycat/mycat2/net/MySQLClientAuthHandler.java
@@ -3,6 +3,7 @@ package io.mycat.mycat2.net;
 import java.io.IOException;
 
 import io.mycat.mycat2.MySQLSession;
+import io.mycat.mycat2.MySQLSession.CurrPacketType;
 import io.mycat.mysql.packet.AuthPacket;
 import io.mycat.proxy.DefaultDirectProxyHandler;
 import io.mycat.proxy.ProxyBuffer;
@@ -22,15 +23,16 @@ public class MySQLClientAuthHandler extends DefaultDirectProxyHandler<MySQLSessi
 
 	@Override
 	public void onFrontRead(MySQLSession session) throws IOException {
-		boolean readed = session.readFromChannel(session.frontBuffer, session.frontChannel);
-		ProxyBuffer backendBuffer = session.frontBuffer;
-		if (readed == false || session.resolveMySQLPackage(backendBuffer, session.curFrontMSQLPackgInf,false) == false) {
+		ProxyBuffer frontBuffer = session.frontBuffer;
+		if(session.readFromChannel(session.frontBuffer, session.frontChannel)==false||
+				CurrPacketType.Full!=session.resolveMySQLPackage(frontBuffer, session.curFrontMSQLPackgInf, false)){
 			return;
 		}
+
 		//处理用户认证请情况报文
 		try {
 			AuthPacket auth = new AuthPacket();
-			auth.read(backendBuffer);
+			auth.read(frontBuffer);
 			// Fake check user
 			logger.debug("Check user name. " + auth.user);
 			// if (!auth.user.equals("root")) {

--- a/source/src/main/java/io/mycat/mycat2/tasks/BackendSynchronzationTask.java
+++ b/source/src/main/java/io/mycat/mycat2/tasks/BackendSynchronzationTask.java
@@ -37,6 +37,7 @@ public class BackendSynchronzationTask extends AbstractBackendIOTask {
         queryPacket.sql = session.isolation.getCmd() + session.autoCommit.getCmd() + session.isolation.getCmd();
         queryPacket.write(frontBuffer);
         frontBuffer.flip();
+        frontBuffer.readIndex = frontBuffer.writeIndex;
         session.writeToChannel(frontBuffer, session.backendChannel);
     }
 

--- a/source/src/main/java/io/mycat/mycat2/tasks/BackendSynchronzationTask.java
+++ b/source/src/main/java/io/mycat/mycat2/tasks/BackendSynchronzationTask.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.mycat.mycat2.MySQLSession;
+import io.mycat.mycat2.MySQLSession.CurrPacketType;
 import io.mycat.mysql.packet.ErrorPacket;
 import io.mycat.mysql.packet.MySQLPacket;
 import io.mycat.mysql.packet.QueryPacket;
@@ -43,7 +44,7 @@ public class BackendSynchronzationTask extends AbstractBackendIOTask {
     public void onBackendRead(MySQLSession session) throws IOException {
         session.frontBuffer.reset();
         if (!session.readFromChannel(session.frontBuffer, session.backendChannel)
-                || !session.resolveMySQLPackage(session.frontBuffer, session.curBackendMSQLPackgInf, false)) {// 没有读到数据或者报文不完整
+                || CurrPacketType.Full != session.resolveMySQLPackage(session.frontBuffer, session.curBackendMSQLPackgInf, false)) {// 没有读到数据或者报文不完整
             return;
         }
         if (session.curBackendMSQLPackgInf.pkgType == MySQLPacket.OK_PACKET) {

--- a/source/src/main/java/io/mycat/mysql/packet/ErrorPacket.java
+++ b/source/src/main/java/io/mycat/mysql/packet/ErrorPacket.java
@@ -60,7 +60,7 @@ public class ErrorPacket extends MySQLPacket {
         packetId =byteBuffer.readByte();
         pkgType =byteBuffer.readByte();
         errno = (int) byteBuffer.readFixInt(2);
-        if (byteBuffer.readState.hasRemain() && (byteBuffer.getByte(byteBuffer.readState.optPostion) == SQLSTATE_MARKER)) {
+        if ((byteBuffer.writeIndex - byteBuffer.readIndex) >0 && (byteBuffer.getByte(byteBuffer.readIndex) == SQLSTATE_MARKER)) {
         	byteBuffer.skip(1);
             sqlState = byteBuffer.readBytes(5);
         }

--- a/source/src/main/java/io/mycat/proxy/ProxyBuffer.java
+++ b/source/src/main/java/io/mycat/proxy/ProxyBuffer.java
@@ -1,44 +1,90 @@
 package io.mycat.proxy;
-
-/**
- * 可重用的Buffer，连续读或者写，当空间不够时Compact擦除之前用过的空间，
- * 处于写状态或者读状态之一，不能同时读写， 只有数据被操作完成（读完或者写完）后State才能被改变（flip方法或手工切换状态），同时可能要改变Owner，chanageOwn
- */
 import java.nio.ByteBuffer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+/**
+ * 可重用的Buffer，连续读或者写，当空间不够时Compact擦除之前用过的空间，
+ * 处于写状态或者读状态之一，不能同时读写， 只有数据被操作完成（读完或者写完）后State才能被改变（flip方法或手工切换状态），同时可能要改变Owner，chanageOwn
+ * 
+ * 需要外部 关心的状态为
+ * writeIndex  写入buffer 开始位置
+ * readIndex   读取开始位置
+ * inReading   当前buffer 读写状态
+ * frontUsing  owner 
+ * 不需要外部关心的状态为
+ * readMark    向channel   中写入数据时的开始位置, 该状态由 writeToChannel 自动维护,不需要外部显式指定
+ * preUsing    上一个owner   仅在     write==0 或只写了一部分数据的情况下,需要临时改变 owner .本次写入完成后,需要根据preUsing 自动切换回来
+ * 使用流程
+ * 一、透传、只前端读写、只后端读写场景
+ * 1. 从channel 向 buffer 写入数据  始终从  writeIndex 开始写入 , inReading 状态一定为  false 写入状态
+ * 2. 读取 buffer 中数据  读取的数据范围是  readIndex --- writeIndex  之间的数据.
+ * 3. 向 channel 写入数据前, flip 切换读写状态
+ * 4. 数据全部透传完成（例如:整个结果集透传完成）后 changeOwner,否则 owner 不变.
+ * 5. 从 buffer  向 channel 写入数据时,写入  readMark--readIndex 之间的数据.
+ * 6. 写完成后 flip 切换读写状态。同时 如果 readIndex > buffer.capacity() * 2 / 3 进行一次压缩
+ * 7. 从 channel 向buffer 写入数据时，如果 writeIndex > buffer.capacity() * 1 / 3 进行一次压缩
+ * 
+ * 二、没有读取数据,向buffer中写入数据后 直接 write 到 channel的场景
+ * 1. 在写入到 channel 时 ,需要显式  指定 readIndex = writeIndex;
+ * 2. 其他步骤 同 （透传、只前端读写、只后端读写场景）场景 
+ * 
+ * @author yanjunli
+ *
+ */
 public class ProxyBuffer {
 	protected static Logger logger = LoggerFactory.getLogger(ProxyBuffer.class);
 	private final ByteBuffer buffer;
 	
+	// 对于Write to Buffer
+	// 的操作，writeIndex表示当前可读的数据截止位置，readMark为数据开始位置，用户可以标记，下次写入Buffer时，从writeIndex的位置继续写入
+
+	// 对于Read to
+	// Channel的操作，readMark表示读取数据截止的位置，writeIndex表示数据截止的位置，0-readMark之间的数据是要被写入CHannel的，写入Channel
+	// 后，Write 完成后检查optMark；当writeIndex >  1/3 capacity 时 执行 compact。将readIndex 与 writeIndex 之间的数据移动到buffer 开始位置 
+
+	/*
+	 * 写入数据开始位置， 从socket buffer  写入数据时,从该位置开始写入
+	 */
+	public int writeIndex;
+	
+	/*
+	 * 用于标记透传时 的结束位置
+	 * 向socket 中吸入数据时,用于标记写入到socket 中数据的结束位置
+	 */
+	public int readIndex;
 	
 	/**
-	 * 通道的读写状态标标识，false为写入，true 为读取
+	 * 当前buffer 的读写状态  . 默认为写入状态 
+	 * false  从 channel 中 向  buffer 写入数据   即： write 状态
+	 * true   从buffer  向 channel 写出数据       即： read  状态
 	 */
 	private boolean inReading = false;
 	
-	
-	/**
-	 * 通道读取的状态标识
-	 */
-	public BufferOptState readState = new BufferOptState();
-	
-	
-	/**
-	 * 通道数据写入状态的标识
-	 */
-	public BufferOptState writeState = new BufferOptState();
 	//一般都是后端连接率先给客户端发起信息，所以后端默认使用
 	private boolean frontUsing=false;
+	
+	
+	/*
+	 * *********************************************************************
+	 * 以下 两个状态 ,不推荐 外部使用. 会在进行网络读写时,网络读写程序内部使用.
+	 * *********************************************************************
+	 */
+	
+	/*
+	 * 用于标记透传时数据开始位置,  这个指针不推荐外部用户 显示调用，由网络读写状态自动管理
+	 * 为减少 compact 次数. 引入第三个指针. 在 writeIndex >  2/3 capacity 时 执行 compact
+	 */
+	public int readMark;
+	
+	// 上一个owner, 外部用户 不需要关心 该值
+	// 在发生 网络阻塞情况下,可能只写出去了 0个字节.
+	// 这时需要 切换 使用者,同时保存当前使用者.用于 数据传输完毕后,切换回来 
+	private Boolean preUsing=null;
 
 	public ProxyBuffer(ByteBuffer buffer) {
 		super();
 		this.buffer = buffer;
-		writeState.startPos = 0;
-		writeState.optPostion = 0;
-		writeState.optLimit = buffer.capacity();
 	}
 
 	public boolean isInReading() {
@@ -47,6 +93,14 @@ public class ProxyBuffer {
 
 	public boolean isInWriting() {
 		return inReading == false;
+	}
+	
+	/**
+	 * 当前还是数据可读
+	 * @return
+	 */
+	public boolean hasRemain(){
+		return (writeIndex - readIndex) > 0;
 	}
 
 	/**
@@ -58,45 +112,27 @@ public class ProxyBuffer {
 		return buffer;
 	}
 
-	public void setInReading(boolean inReading) {
-		this.inReading = inReading;
-	}
-
-	public void changeOwner(boolean front)
+	public ProxyBuffer changeOwner(boolean front)
 	{
 		this.frontUsing=front;
+		return this;
 	}
-	/**
-	 * 交换Read与Write状态
-	 */
-	public void flip() {
-
-		if (this.inReading) {
-			// 转为可写状态
-			inReading = false;
-			writeState.startPos = 0;
-			writeState.optPostion = 0;
-			writeState.optLimit = buffer.capacity();
-			writeState.optedTotalLength = 0;
-			// 转为可写状态时恢复读状态为初始（不可读）
-			readState.startPos = 0;
-			readState.optPostion = 0;
-			readState.optLimit = 0;
-		} else {
-			// 转为读状态
-			inReading = true;
-			//读取状态的开始指针指定为写入状态的开始指针
-			readState.startPos = writeState.startPos;
-			//opt指针指定为状态开始的指针
-			readState.optPostion = writeState.startPos;
-			//读取的最大长度指定为现写入的长度
-			readState.optLimit = writeState.optPostion;
-			//总字节数转换为0
-			readState.optedTotalLength = 0;
-		}
-		logger.debug("flip, new state {} , write state: {} ,read state {}", this.inReading ? "read" : "write",
-				this.writeState, this.readState);
-
+	
+	public boolean frontUsing() {
+		return this.frontUsing;
+	}
+	
+	public boolean backendUsing()
+	{
+		return !frontUsing;
+	}
+	
+	public void reset()
+	{
+		this.readMark=0;
+		this.readIndex=0;
+		this.writeIndex=0;
+		this.buffer.clear();
 	}
 
 	/**
@@ -105,37 +141,31 @@ public class ProxyBuffer {
 	 * @param step
 	 */
 	public void skip(int step) {
-		this.readState.optPostion += step;
-	}
-
-	public BufferOptState getReadOptState() {
-		return this.readState;
-	}
-
-	public BufferOptState getWriteOptState() {
-		return this.writeState;
+		readIndex += step;
 	}
 
 	/**
 	 * 写状态时候，如果数据写满了，可以调用此方法移除之前的旧数据
 	 */
-	public void compact(boolean synReadStatePos) {
-		if (this.inReading) {
-			throw new RuntimeException("not in writing state ,can't Compact");
-		}
-		this.buffer.position(writeState.startPos);
-		this.buffer.limit(writeState.optPostion);
+	public void compact() {
+		
+		this.buffer.position(readMark);
+		this.buffer.limit(writeIndex);
 		this.buffer.compact();
-		int offset = writeState.startPos;
-		writeState.startPos = 0;
-		writeState.optPostion = buffer.limit();
-		writeState.optLimit = buffer.capacity();
-		buffer.limit(buffer.capacity());
-		if (synReadStatePos) {
-			readState.optPostion -= offset;
-			readState.optLimit -= offset;
+		readIndex -= readMark;
+		readMark = 0;
+		writeIndex = buffer.position();
+	}
+	
+	/**
+	 * 交换Read与Write状态
+	 */
+	public void flip() {
+		if (this.inReading) {
+			this.inReading = false;
+		}else{
+			this.inReading = true;
 		}
-
 	}
 
 	public ProxyBuffer writeBytes(byte[] bytes) {
@@ -144,31 +174,30 @@ public class ProxyBuffer {
 	}
 
 	public long readFixInt(int length) {
-		long val = getInt(readState.optPostion, length);
-		this.readState.optPostion += length;
+		long val = getInt(readIndex, length);
+		readIndex += length;
 		return val;
 	}
 
 	public long readLenencInt() {
-		int index = readState.optPostion;
-		long len = getInt(readState.optPostion, 1) & 0xff;
+		int index = readIndex;
+		long len = getInt(index, 1) & 0xff;
 		if (len < 251) {
-			this.readState.optPostion += 1;
+			readIndex += 1;
 			return getInt(index, 1);
 		} else if (len == 0xfc) {
-			this.readState.optPostion += 2;
+			readIndex += 2;
 			return getInt(index + 1, 2);
 		} else if (len == 0xfd) {
-			this.readState.optPostion += 3;
+			readIndex += 3;
 			return getInt(index + 1, 3);
 		} else {
-			this.readState.optPostion += 8;
+			readIndex += 8;
 			return getInt(index + 1, 8);
 		}
 	}
 
 	public long getInt(int index, int length) {
-		buffer.limit(index + length);
 		buffer.position(index);
 		long rv = 0;
 		for (int i = 0; i < length; i++) {
@@ -179,7 +208,6 @@ public class ProxyBuffer {
 	}
 
 	public byte[] getBytes(int index, int length) {
-		buffer.limit(length + index);
 		buffer.position(index);
 		byte[] bytes = new byte[length];
 		buffer.get(bytes);
@@ -187,7 +215,6 @@ public class ProxyBuffer {
 	}
 
 	public byte getByte(int index) {
-		buffer.limit(index + 1);
 		buffer.position(index);
 		byte b = buffer.get();
 		return b;
@@ -199,8 +226,8 @@ public class ProxyBuffer {
 	}
 
 	public String readFixString(int length) {
-		byte[] bytes = getBytes(readState.optPostion, length);
-		readState.optPostion += length;
+		byte[] bytes = getBytes(readIndex, length);
+		readIndex += length;
 		return new String(bytes);
 	}
 
@@ -212,10 +239,10 @@ public class ProxyBuffer {
 	}
 
 	public String readLenencString() {
-		int strLen = (int) getLenencInt(readState.optPostion);
+		int strLen = (int) getLenencInt(readIndex);
 		int lenencLen = getLenencLength(strLen);
-		byte[] bytes = getBytes(readState.optPostion + lenencLen, strLen);
-		this.readState.optPostion += strLen + lenencLen;
+		byte[] bytes = getBytes(readIndex + lenencLen, strLen);
+		readIndex += strLen + lenencLen;
 		return new String(bytes);
 	}
 
@@ -230,7 +257,7 @@ public class ProxyBuffer {
 	public String getNULString(int index) {
 		int strLength = 0;
 		int scanIndex = index;
-		while (scanIndex < readState.optLimit) {
+		while (scanIndex < writeIndex) {
 			if (getByte(scanIndex++) == 0) {
 				break;
 			}
@@ -241,8 +268,8 @@ public class ProxyBuffer {
 	}
 
 	public String readNULString() {
-		String rv = getNULString(readState.optPostion);
-		readState.optPostion += rv.getBytes().length + 1;
+		String rv = getNULString(readIndex);
+		readIndex += rv.getBytes().length + 1;
 		return rv;
 	}
 
@@ -256,8 +283,8 @@ public class ProxyBuffer {
 	}
 
 	public ProxyBuffer writeFixInt(int length, long val) {
-		putFixInt(writeState.optPostion, length, val);
-		writeState.optPostion += length;
+		putFixInt(writeIndex, length, val);
+		writeIndex += length;
 		return this;
 	}
 
@@ -279,19 +306,19 @@ public class ProxyBuffer {
 
 	public ProxyBuffer writeLenencInt(long val) {
 		if (val < 251) {
-			putByte(writeState.optPostion++, (byte) val);
+			putByte(writeIndex++, (byte) val);
 		} else if (val >= 251 && val < (1 << 16)) {
-			putByte(writeState.optPostion++, (byte) 0xfc);
-			putFixInt(writeState.optPostion, 2, val);
-			writeState.optPostion += 2;
+			putByte(writeIndex++, (byte) 0xfc);
+			putFixInt(writeIndex, 2, val);
+			writeIndex += 2;
 		} else if (val >= (1 << 16) && val < (1 << 24)) {
-			putByte(writeState.optPostion++, (byte) 0xfd);
-			putFixInt(writeState.optPostion, 3, val);
-			writeState.optPostion += 3;
+			putByte(writeIndex++, (byte) 0xfd);
+			putFixInt(writeIndex, 3, val);
+			writeIndex += 3;
 		} else {
-			putByte(writeState.optPostion++, (byte) 0xfe);
-			putFixInt(writeState.optPostion, 8, val);
-			writeState.optPostion += 8;
+			putByte(writeIndex++, (byte) 0xfe);
+			putFixInt(writeIndex, 8, val);
+			writeIndex += 8;
 		}
 		return this;
 	}
@@ -302,8 +329,8 @@ public class ProxyBuffer {
 	}
 
 	public ProxyBuffer writeFixString(String val) {
-		putBytes(writeState.optPostion, val.getBytes());
-		writeState.optPostion += val.getBytes().length;
+		putBytes(writeIndex, val.getBytes());
+		writeIndex += val.getBytes().length;
 		return this;
 	}
 
@@ -315,9 +342,9 @@ public class ProxyBuffer {
 	}
 
 	public ProxyBuffer writeLenencString(String val) {
-		putLenencString(writeState.optPostion, val);
+		putLenencString(writeIndex, val);
 		int lenencLen = getLenencLength(val.getBytes().length);
-		writeState.optPostion += lenencLen + val.getBytes().length;
+		writeIndex += lenencLen + val.getBytes().length;
 		return this;
 	}
 
@@ -336,14 +363,12 @@ public class ProxyBuffer {
 	}
 
 	public ProxyBuffer putBytes(int index, int length, byte[] bytes) {
-		buffer.limit(index + length);
 		buffer.position(index);
 		buffer.put(bytes);
 		return this;
 	}
 
 	public ProxyBuffer putByte(int index, byte val) {
-		buffer.limit(index + 1);
 		buffer.position(index);
 		buffer.put(val);
 		return this;
@@ -356,40 +381,40 @@ public class ProxyBuffer {
 	}
 
 	public ProxyBuffer writeNULString(String val) {
-		putNULString(writeState.optPostion, val);
-		writeState.optPostion += val.getBytes().length + 1;
+		putNULString(writeIndex, val);
+		writeIndex += val.getBytes().length + 1;
 		return this;
 	}
 
 	public byte[] readBytes(int length) {
-		byte[] bytes = this.getBytes(readState.optPostion, length);
-		readState.optPostion += length;
+		byte[] bytes = this.getBytes(readIndex, length);
+		readIndex += length;
 		return bytes;
 	}
 
 	public ProxyBuffer writeBytes(int length, byte[] bytes) {
-		this.putBytes(writeState.optPostion, length, bytes);
-		writeState.optPostion += length;
+		this.putBytes(writeIndex, length, bytes);
+		writeIndex += length;
 		return this;
 	}
 
 	public ProxyBuffer writeLenencBytes(byte[] bytes) {
-		putLenencInt(writeState.optPostion, bytes.length);
+		putLenencInt(writeIndex, bytes.length);
 		int offset = getLenencLength(bytes.length);
-		putBytes(writeState.optPostion + offset, bytes);
-		writeState.optPostion += offset + bytes.length;
+		putBytes(writeIndex + offset, bytes);
+		writeIndex += offset + bytes.length;
 		return this;
 	}
 
 	public ProxyBuffer writeByte(byte val) {
-		this.putByte(writeState.optPostion, val);
-		writeState.optPostion++;
+		this.putByte(writeIndex, val);
+		writeIndex++;
 		return this;
 	}
 
 	public byte readByte() {
-		byte val = getByte(readState.optPostion);
-		readState.optPostion++;
+		byte val = getByte(readIndex);
+		readIndex++;
 		return val;
 	}
 
@@ -431,9 +456,9 @@ public class ProxyBuffer {
 	}
 
 	public byte[] readLenencBytes() {
-		int len = (int) getLenencInt(readState.optPostion);
-		byte[] bytes = getBytes(readState.optPostion + getLenencLength(len), len);
-		readState.optPostion += getLenencLength(len) + len;
+		int len = (int) getLenencInt(readIndex);
+		byte[] bytes = getBytes(readIndex + getLenencLength(len), len);
+		readIndex += getLenencLength(len) + len;
 		return bytes;
 	}
 
@@ -445,26 +470,22 @@ public class ProxyBuffer {
 	}
 
 	/**
-	 * Reset to write状态，清除数据
+	 * 是否需要自动切换owner
+	 * @return
 	 */
-	public void reset() {
-		inReading = false;
-		writeState.optPostion = 0;
-		writeState.optLimit = buffer.capacity();
-		writeState.curOptedLength = 0;
-		writeState.optedTotalLength = 0;
-		readState.optPostion = 0;
-		readState.optLimit = 0;
-		readState.curOptedLength = 0;
-		readState.optedTotalLength = 0;
+	public boolean needAutoChangeOwner() {
+		return (preUsing!=null&&frontUsing!=preUsing)?true:false;
 	}
 
-	public boolean frontUsing() {
-		return this.frontUsing;
-	}
-	public boolean backendUsing()
-	{
-		return !frontUsing;
+	public ProxyBuffer setPreUsing(Boolean preUsing) {
+		this.preUsing = preUsing;
+		return this;
 	}
 
+	@Override
+	public String toString() {
+		return "ProxyBuffer [buffer=" + buffer + ", writeIndex=" + writeIndex + ", readIndex=" + readIndex
+				+ ", readMark=" + readMark + ", inReading=" + inReading + ", frontUsing=" + frontUsing + ", preUsing="
+				+ preUsing + "]";
+	}
 }

--- a/source/src/main/java/io/mycat/proxy/UserProxySession.java
+++ b/source/src/main/java/io/mycat/proxy/UserProxySession.java
@@ -36,21 +36,23 @@ public class UserProxySession extends AbstractSession {
 	public boolean readFromChannel(ProxyBuffer proxyBuf, SocketChannel channel) throws IOException {
 
 		ByteBuffer buffer = proxyBuf.getBuffer();
-		buffer.limit(proxyBuf.writeState.optLimit);
-		buffer.position(proxyBuf.writeState.optPostion);
+		if (proxyBuf.writeIndex > buffer.capacity() * 1 / 3) {
+			proxyBuf.compact();
+		}else{
+			// buffer.position 在有半包没有参与透传时,会小于 writeIndex。
+			// 大部分情况下   position == writeIndex
+			buffer.position(proxyBuf.writeIndex);
+		}
+		
 		int readed = channel.read(buffer);
-		logger.debug(" readed {} total bytes ,channel {}", readed, channel);
-		proxyBuf.writeState.curOptedLength = readed;
-		if (readed > 0) {
-			proxyBuf.writeState.optPostion += readed;
-			proxyBuf.writeState.optedTotalLength += readed;
-			proxyBuf.readState.optLimit = proxyBuf.writeState.optPostion;
-		} else if (readed == -1) {
+		logger.debug(" readed {} total bytes ", readed);
+		if (readed == -1) {
 			logger.warn("Read EOF ,socket closed ");
 			throw new ClosedChannelException();
 		} else if (readed == 0) {
 			logger.warn("readed zero bytes ,Maybe a bug ,please fix it !!!!");
 		}
+		proxyBuf.writeIndex = buffer.position();
 		return readed > 0;
 	}
 
@@ -60,32 +62,44 @@ public class UserProxySession extends AbstractSession {
 	 * @param channel
 	 */
 	public void writeToChannel(ProxyBuffer proxyBuf, SocketChannel channel) throws IOException {
+		
 		ByteBuffer buffer = proxyBuf.getBuffer();
-		BufferOptState readState = proxyBuf.readState;
-		BufferOptState writeState = proxyBuf.writeState;
-		buffer.position(readState.optPostion);
-		buffer.limit(readState.optLimit);
+		buffer.limit(proxyBuf.readIndex);
+		buffer.position(proxyBuf.readMark);
 		int writed = channel.write(buffer);
-		readState.curOptedLength = writed;
-		readState.optPostion += writed;
-		readState.optedTotalLength += writed;
-		if (buffer.remaining() == 0) {
-			if (writeState.optPostion > buffer.position()) {
-				// 当前Buffer中写入的数据多于透传出去的数据，因此透传并未完成
-				// compact buffer to head
-				buffer.limit(writeState.optPostion);
-				buffer.compact();
-				readState.optPostion = 0;
-				readState.optLimit = buffer.position();
-				writeState.optPostion = buffer.position();
-				// 继续从对端Socket读数据
-			} else {
-				// 数据彻底写完，切换为读模式，对端读取数据
-				proxyBuf.changeOwner(!proxyBuf.frontUsing());
-				proxyBuf.flip();
+		proxyBuf.readMark += writed;   //记录本次磁轭如到 Channel 中的数据
+		if(!buffer.hasRemaining()){
+			logger.debug("writeToChannel write  {} bytes ",writed);
+			// buffer 中需要透传的数据全部写入到 channel中后,会进入到当前分支.这时 readIndex == readLimit
+			if(proxyBuf.readMark != proxyBuf.readIndex){
+				logger.error("writeToChannel has finished but readIndex != readLimit, please fix it !!!");
 			}
+			if (proxyBuf.readIndex > buffer.capacity() * 2 / 3) {
+				proxyBuf.compact();
+			}else{
+				buffer.limit(buffer.capacity());
+			}
+			//切换读写状态
+			proxyBuf.flip();
+			/*
+			 * 如果需要自动切换owner,进行切换  
+			 * 1. writed==0 或者  buffer 中数据没有写完时,注册可写事件 时,会进行owner 切换 注册写事件,完成后,需要自动切换回来
+			 */
+			if(proxyBuf.needAutoChangeOwner()){
+				proxyBuf.changeOwner(!proxyBuf.frontUsing()).setPreUsing(null);
+			}
+		}else{
+			/**
+			 * 1. writed==0 或者  buffer 中数据没有写完时,注册可写事件
+			 *    通常发生在网络阻塞或者 客户端  COM_STMT_FETCH 命令可能会 出现没有写完或者 writed == 0 的情况
+			 */
+			logger.debug("register OP_WRITE  selectkey .write  {} bytes. current channel is {}",writed,channel);
+			//需要切换 owner ,同时保存当前 owner 用于数据传输完成后,再切换回来
+			// proxyBuf 读写状态不切换,会切换到相同的事件,不会重复注册
+			proxyBuf.setPreUsing(proxyBuf.frontUsing())
+					.changeOwner(!proxyBuf.frontUsing());
 		}
-		this.modifySelectKey();
+		modifySelectKey();
 	}
 
 	/**
@@ -162,8 +176,8 @@ public class UserProxySession extends AbstractSession {
 
 	public void modifySelectKey() throws ClosedChannelException {
 		SelectionKey theKey = this.frontBuffer.frontUsing() ? frontKey : backendKey;
+		int clientOps = SelectionKey.OP_READ;
 		if (theKey != null && theKey.isValid()) {
-			int clientOps = SelectionKey.OP_READ;
 			if (frontBuffer.isInWriting() == false) {
 				clientOps = SelectionKey.OP_WRITE;
 			}
@@ -172,5 +186,13 @@ public class UserProxySession extends AbstractSession {
 				theKey.interestOps(clientOps);
 			}
 		}
+		logger.info(" current selectkey is {},channel is {}",theKey.interestOps(),theKey.channel());
+		//取消对端 读写事件
+		SelectionKey otherKey = this.frontBuffer.frontUsing() ? backendKey : frontKey;
+		if(otherKey!=null&&otherKey.isValid()){
+			otherKey.interestOps(otherKey.interestOps() & ~(SelectionKey.OP_WRITE | SelectionKey.OP_READ));
+			logger.info(" other selectkey is {},channel is {}",otherKey.interestOps(),otherKey.channel());
+		}
+		
 	}
 }


### PR DESCRIPTION
1.重构proxybuffer 外部操作指针减少到两个.
2.根据 buffer 的 owner 及 read/write 状态,进行事件切换。。。。
3.write 0 字节时, 切换owner,并注册可写事件. 写完后,自动切换回原owner.
4.取消 limit. compact 在buffer使用超过容量的 1/3 或2/3时 触发。。。。
5.修复sql解析器 偶尔报数组越界的问题.
6.修改变量命名，，增加注释，，删除不必要的方法

已验证
同步命令
超多列结果集透传
超多行结果集透传.
超大列结果集透传