### PR TITLE
1、解决关闭后端连接出现空指针异常

### DIFF
--- a/source/src/main/java/io/mycat/mycat2/MySQLSession.java
+++ b/source/src/main/java/io/mycat/mycat2/MySQLSession.java
@@ -57,6 +57,14 @@ public class MySQLSession extends AbstractMySQLSession {
 		
 	}
 
+	@Override
+	protected void afterOnClose() {
+		// TODO Auto-generated method stub
+		if(mycatSession != null ) {
+			mycatSession.unBindBackend();
+		}
+	}
 
+	
 
 }

--- a/source/src/main/java/io/mycat/mycat2/MycatSession.java
+++ b/source/src/main/java/io/mycat/mycat2/MycatSession.java
@@ -114,6 +114,16 @@ public class MycatSession extends AbstractMySQLSession {
 		backend.useSharedBuffer(this.proxyBuffer);
 		backend.setCurNIOHandler(this.getCurNIOHandler());
 	}
+	
+	/**
+	 * 解绑后端的MySQL会话，后端连接如果关闭，应该是需要解除联系的
+	 * 目前前端连接在需要后短连接时，如果后端连接为空，会重新获取一个后端连接
+	 * DefaultMycatSessionHandler.syncSessionStateToBackend 目前并没有判断其拥有的后端连接是否为空，但目前该方法未使用，需要注意
+	 * 该方法建议调用的时机为：后端连接关闭
+	 */
+	public void unBindBackend() {
+		this.backend = null;
+	}
 
 	/**
 	 * 获取ProxyBuffer控制权，同时设置感兴趣的事件，如SocketRead，Write，只能其一
@@ -191,5 +201,15 @@ public class MycatSession extends AbstractMySQLSession {
 		this.takeOwner(SelectionKey.OP_READ);
 
 	}
+
+	
+	//@todo 前端连接关闭后，需要归还占有的后端连接，待连接池实现后
+	@Override
+	protected void afterOnClose() {
+		// TODO Auto-generated method stub
+		super.afterOnClose();
+	}
+	
+	
 
 }

--- a/source/src/main/java/io/mycat/proxy/AbstractSession.java
+++ b/source/src/main/java/io/mycat/proxy/AbstractSession.java
@@ -262,17 +262,31 @@ public abstract class AbstractSession implements Session {
 	 */
 	public void close(boolean normal, String hint) {
 		if (!this.isClosed()) {
+			
+			System.out.println(this);
 			this.closed = true;
 			logger.info("close session " + this.sessionInfo() + " for reason " + hint);
 			closeSocket(channel, normal, hint);
 			if (!referedBuffer) {
 				this.bufPool.recycleBuf(proxyBuffer.getBuffer());
 			}
-			this.getMySessionManager().removeSession(this);
+			
+			if(this.getMySessionManager() != null ) {
+				this.getMySessionManager().removeSession(this);
+			}
+			
+			afterOnClose();
 		} else {
 			logger.warn("session already closed " + this.sessionInfo());
 		}
 
+	}
+	
+	/**
+	 * 连接关闭，子类特殊的业务逻辑实现
+	 */
+	protected void afterOnClose() {
+		
 	}
 
 	@SuppressWarnings("rawtypes")


### PR DESCRIPTION
   原因：目前后端连接对象的SessionManager为空，在关闭连接时需要调用SessionManage
               移除连接。
2、解决方法
   在AbstractSession的close方法中，如果SessionManager为空，则不调用移除Session方法
  并增加一个钩子方法afterOnClose，由子类去实现，比如关闭后端连接时，应该取消前后端连接的
 绑定关系，关闭前端连接时，需要将后端连接归还到后端连接池