### PR TITLE
修复命令行登录报错的问题

### DIFF
--- a/source/pom.xml
+++ b/source/pom.xml
@@ -207,7 +207,7 @@
 							<id>mycat</id>
 							<mainClass>io.mycat.mycat2.MycatCore</mainClass>
 							<commandLineArguments>
-								<commandLineArgument>start</commandLineArgument>
+								<commandLineArgument>1</commandLineArgument>
 							</commandLineArguments>
 							<platforms>
 								<platform>jsw</platform>

--- a/source/src/main/java/io/mycat/mycat2/cmds/DirectPassthrouhCmd.java
+++ b/source/src/main/java/io/mycat/mycat2/cmds/DirectPassthrouhCmd.java
@@ -51,6 +51,7 @@ public class DirectPassthrouhCmd implements MySQLCommand {
 				ProxyBuffer curBuffer = session.proxyBuffer;
 				// 切换 buffer 读写状态
 				curBuffer.flip();
+
 				// 没有读取,直接透传时,需要指定 透传的数据 截止位置
 				curBuffer.readIndex = curBuffer.writeIndex;
 				// 改变 owner，对端Session获取，并且感兴趣写事件
@@ -89,8 +90,6 @@ public class DirectPassthrouhCmd implements MySQLCommand {
 	public boolean onFrontWriteFinished(MycatSession session) throws IOException {
 		// 判断是否结果集传输完成，决定命令是否结束，切换到前端读取数据
 		// 检查当前已经结束，进行切换
-		logger.warn("not well implemented ,please fix it ");
-
 		// 检查如果存在传输的标识，说明后传数据向前传传输未完成,注册后端的读取事件
 		if (session.getSessionAttrMap().containsKey(SessionKeyEnum.SESSION_KEY_TRANSFER_OVER_FLAG.getKey())) {
 			session.proxyBuffer.flip();

--- a/source/src/main/java/io/mycat/proxy/AbstractSession.java
+++ b/source/src/main/java/io/mycat/proxy/AbstractSession.java
@@ -77,9 +77,10 @@ public abstract class AbstractSession implements Session {
 		if (this.proxyBuffer != null && referedBuffer == false) {
 			this.bufPool.recycleBuf(proxyBuffer.getBuffer());
 			proxyBuffer = sharedBuffer;
+			this.referedBuffer = true;
+		}else if(sharedBuffer==null){
+			this.referedBuffer = false;
 		}
-		this.referedBuffer = true;
-
 	}
 
 	public boolean isCurBufOwner() {

--- a/source/src/main/java/io/mycat/proxy/AbstractSession.java
+++ b/source/src/main/java/io/mycat/proxy/AbstractSession.java
@@ -136,7 +136,7 @@ public abstract class AbstractSession implements Session {
 			throw new java.lang.IllegalArgumentException("buffer not changed to me ");
 		} else if (this.proxyBuffer.isInReading() != bufferReadstate) {
 			throw new java.lang.IllegalArgumentException(
-					"buffer not in correcte state ,expected state  " + (bufferReadstate ? " readable " : "writable "));
+					"buffer not in correcte state ,expected state  " + (bufferReadstate ? " readable " : "writable ") + this.channel);
 		}
 	}
 
@@ -211,8 +211,10 @@ public abstract class AbstractSession implements Session {
 	protected void checkWriteFinished() throws IOException {
 		checkBufferOwner(true);
 		if (!this.proxyBuffer.writeFinished()) {
+			logger.debug("curr proxyBuffer has not writeFinished! change2WriteOpts" + this);
 			this.change2WriteOpts();
 		} else {
+			logger.debug("curr proxyBuffer has writeFinished! " + this);
 			writeFinished();
 			// clearReadWriteOpts();
 		}
@@ -221,10 +223,11 @@ public abstract class AbstractSession implements Session {
 	
 	public void change2ReadOpts() {
 		//不做检查，因为两个chanel不确定哪个会对读事件感兴趣，因此通常会都设置为读感兴趣
-		int intesOpts = this.channelKey.interestOps();
+		
 		// 事件转换时,只注册一个事件,存在可写事件没有取消注册的情况。这里把判断取消
 //		if ((intesOpts & SelectionKey.OP_READ) != SelectionKey.OP_READ) {
-			channelKey.interestOps(SelectionKey.OP_READ);
+		logger.debug(channel+" interestOps OP_READ ");
+		channelKey.interestOps(SelectionKey.OP_READ);
 //		}
 	}
 
@@ -237,7 +240,8 @@ public abstract class AbstractSession implements Session {
 		int intesOpts = this.channelKey.interestOps();
 		// 事件转换时,只注册一个事件,存在可读事件没有取消注册的情况。这里把判断取消
 //		if ((intesOpts & SelectionKey.OP_WRITE) != SelectionKey.OP_WRITE) {
-			channelKey.interestOps(SelectionKey.OP_WRITE);
+		logger.debug(channel+" interestOps OP_WRITE ");
+		channelKey.interestOps(SelectionKey.OP_WRITE);
 //		}
 	}
 


### PR DESCRIPTION
1. 修复 从其他reactor 获取后端连接，解绑时，referedBuffer 标记设置错误的问题。
2. 从其他 reactor 借来连接时，感兴趣事件 转移到当前reactor。
3. 放弃控制权时，不主动注册可写事件。

