### PR TITLE
bugfix:字符集的加载

### DIFF
--- a/source/src/main/java/io/mycat/mycat2/MycatConfig.java
+++ b/source/src/main/java/io/mycat/mycat2/MycatConfig.java
@@ -83,7 +83,8 @@ public class MycatConfig {
 	}
 
 	public int getConfigVersion(ConfigEnum configEnum) {
-		return configVersionMap.get(configEnum);
+        Integer oldVersion = configVersionMap.get(configEnum);
+        return oldVersion == null ? GlobalBean.INIT_VERSION : oldVersion;
 	}
 
     public Map<String, MySQLRepBean> getMysqlRepMap() {

--- a/source/src/main/java/io/mycat/mycat2/MycatSession.java
+++ b/source/src/main/java/io/mycat/mycat2/MycatSession.java
@@ -355,7 +355,7 @@ public class MycatSession extends AbstractMySQLSession {
 		MySQLMetaBean targetMetaBean = repBean.getBalanceMetaBean(runOnSlave);
 		
 		if(targetMetaBean==null){
-			String errmsg = " the metaBean is not found,please check datasource.yaml!!! [balance] and [type]  propertie or see debug log or check heartbeat task!!";
+			String errmsg = " the metaBean is not found,please check datasource.yml!!! [balance] and [type]  propertie or see debug log or check heartbeat task!!";
 			if(logger.isDebugEnabled()){
 				logger.error(errmsg);
 			}

--- a/source/src/main/java/io/mycat/mycat2/ProxyStarter.java
+++ b/source/src/main/java/io/mycat/mycat2/ProxyStarter.java
@@ -83,7 +83,6 @@ public class ProxyStarter {
 			ProxyRuntime.INSTANCE.getConfig().initRepMap();
 			ProxyRuntime.INSTANCE.getConfig().initSchemaMap();
 
-			// 初始化连接
 			conf.getMysqlRepMap().forEach((repName, repBean) -> {
 				repBean.initMaster();
 				repBean.getMetaBeans().forEach(metaBean -> metaBean.prepareHeartBeat(repBean, repBean.getDataSourceInitStatus()));

--- a/source/src/main/java/io/mycat/mycat2/ProxyStarter.java
+++ b/source/src/main/java/io/mycat/mycat2/ProxyStarter.java
@@ -86,13 +86,7 @@ public class ProxyStarter {
 			// 初始化连接
 			conf.getMysqlRepMap().forEach((repName, repBean) -> {
 				repBean.initMaster();
-				repBean.getMetaBeans().forEach(metaBean -> {
-					try {
-						metaBean.init(repBean, runtime.maxdataSourceInitTime, repBean.getDataSourceInitStatus());
-					} catch (IOException e) {
-						LOGGER.error("error to init metaBean: {}", metaBean.getDsMetaBean().getHostName());
-					}
-				});
+				repBean.getMetaBeans().forEach(metaBean -> metaBean.prepareHeartBeat(repBean, repBean.getDataSourceInitStatus()));
 			});
 		}
 

--- a/source/src/main/java/io/mycat/mycat2/beans/MySQLMetaBean.java
+++ b/source/src/main/java/io/mycat/mycat2/beans/MySQLMetaBean.java
@@ -58,7 +58,7 @@ public class MySQLMetaBean {
 
     private int slaveThreshold = -1;
 
-    public boolean charsetLoaded = false;
+    public static boolean charsetLoaded = false;
 
     /** collationIndex 和 charsetName 的映射 */
     public static final Map<Integer, String> INDEX_TO_CHARSET = new HashMap<>();
@@ -86,8 +86,8 @@ public class MySQLMetaBean {
                         if (exeSucces) {
                             //设置当前连接 读写分离属性
                             optSession.setDefaultChannelRead(this.isSlaveNode());
-                            if (this.charsetLoaded == false) {
-                                this.charsetLoaded = true;
+                            if (MySQLMetaBean.charsetLoaded == false) {
+								MySQLMetaBean.charsetLoaded = true;
                                 logger.info("load charset for MySQLMetaBean {}:{}", this.dsMetaBean.getIp(), this.dsMetaBean.getPort());
                                 BackendCharsetReadTask backendCharsetReadTask = new BackendCharsetReadTask(optSession, this,getConTask);
                                 optSession.setCurNIOHandler(backendCharsetReadTask);
@@ -98,7 +98,7 @@ public class MySQLMetaBean {
 							optSession.change2ReadOpts();
 							reactorThread.addMySQLSession(this, optSession);
 						} else {
-							this.charsetLoaded = false;
+							MySQLMetaBean.charsetLoaded = false;
 							getConTask.finished(optSession,sender,exeSucces,retVal);
                         }
                     });

--- a/source/src/main/java/io/mycat/mycat2/beans/MySQLMetaBean.java
+++ b/source/src/main/java/io/mycat/mycat2/beans/MySQLMetaBean.java
@@ -58,12 +58,12 @@ public class MySQLMetaBean {
 
     private int slaveThreshold = -1;
 
-    public static boolean charsetLoaded = false;
+    public boolean charsetLoaded = false;
 
     /** collationIndex 和 charsetName 的映射 */
-    public static final Map<Integer, String> INDEX_TO_CHARSET = new HashMap<>();
+    public final Map<Integer, String> INDEX_TO_CHARSET = new HashMap<>();
     /** charsetName 到 默认collationIndex 的映射 */
-    public static final Map<String, Integer> CHARSET_TO_INDEX = new HashMap<>();
+    public final Map<String, Integer> CHARSET_TO_INDEX = new HashMap<>();
 
     public void prepareHeartBeat(MySQLRepBean repBean, int status) {
 		logger.info("prepare heart beat for MySQLMetaBean {} ", this);
@@ -86,8 +86,8 @@ public class MySQLMetaBean {
                         if (exeSucces) {
                             //设置当前连接 读写分离属性
                             optSession.setDefaultChannelRead(this.isSlaveNode());
-                            if (MySQLMetaBean.charsetLoaded == false) {
-								MySQLMetaBean.charsetLoaded = true;
+                            if (this.charsetLoaded == false) {
+								this.charsetLoaded = true;
                                 logger.info("load charset for MySQLMetaBean {}:{}", this.dsMetaBean.getIp(), this.dsMetaBean.getPort());
                                 BackendCharsetReadTask backendCharsetReadTask = new BackendCharsetReadTask(optSession, this,getConTask);
                                 optSession.setCurNIOHandler(backendCharsetReadTask);
@@ -98,7 +98,7 @@ public class MySQLMetaBean {
 							optSession.change2ReadOpts();
 							reactorThread.addMySQLSession(this, optSession);
 						} else {
-							MySQLMetaBean.charsetLoaded = false;
+							this.charsetLoaded = false;
 							getConTask.finished(optSession,sender,exeSucces,retVal);
                         }
                     });

--- a/source/src/main/java/io/mycat/mycat2/beans/MySQLMetaBean.java
+++ b/source/src/main/java/io/mycat/mycat2/beans/MySQLMetaBean.java
@@ -54,6 +54,7 @@ public class MySQLMetaBean {
     private volatile long heartbeatRecoveryTime;  // 心跳暂停时间
     private DBHeartbeat heartbeat;
     private MySQLRepBean repBean;
+    private int index;
 
     private int slaveThreshold = -1;
 
@@ -64,11 +65,14 @@ public class MySQLMetaBean {
     /** charsetName 到 默认collationIndex 的映射 */
     public static final Map<String, Integer> CHARSET_TO_INDEX = new HashMap<>();
 
-    public boolean init(MySQLRepBean repBean,long maxwaitTime,int status) throws IOException {
-    	logger.info("init backend myqsl source ,create connections total " + dsMetaBean.getMinCon() + " for " + dsMetaBean.getHostName() + " index :" + repBean.getWriteIndex());
+    public void prepareHeartBeat(MySQLRepBean repBean, int status) {
+		logger.info("prepare heart beat for MySQLMetaBean {} ", this);
+		this.repBean = repBean;
+		this.heartbeat = new MySQLHeartbeat(this,status);
+	}
 
-    	this.repBean = repBean;
-    	heartbeat = new MySQLHeartbeat(this,status);
+    public void init() throws IOException {
+		logger.info("init backend connection for MySQLMetaBean {} ", this);
     	ProxyRuntime runtime = ProxyRuntime.INSTANCE;
         MycatReactorThread[] reactorThreads = (MycatReactorThread[]) runtime.getReactorThreads();
         int reactorSize = runtime.getNioReactorThreads();
@@ -84,6 +88,7 @@ public class MySQLMetaBean {
                             optSession.setDefaultChannelRead(this.isSlaveNode());
                             if (this.charsetLoaded == false) {
                                 this.charsetLoaded = true;
+                                logger.info("load charset for MySQLMetaBean {}:{}", this.dsMetaBean.getIp(), this.dsMetaBean.getPort());
                                 BackendCharsetReadTask backendCharsetReadTask = new BackendCharsetReadTask(optSession, this,getConTask);
                                 optSession.setCurNIOHandler(backendCharsetReadTask);
                                 backendCharsetReadTask.readCharset();
@@ -97,23 +102,11 @@ public class MySQLMetaBean {
 							getConTask.finished(optSession,sender,exeSucces,retVal);
                         }
                     });
-                } catch (IOException ignore) {
+                } catch (IOException e) {
+                	logger.error("error to load charset for metaBean {}", this, e);
                 }
             });
         }
-        
-        long timeOut = System.currentTimeMillis() + maxwaitTime;
-
-		// waiting for finish
-		while (!getConTask.finished() && (System.currentTimeMillis() < timeOut)) {
-			try {
-				Thread.sleep(100);
-			} catch (InterruptedException e) {
-				logger.error("initError", e);
-			}
-		}
-		logger.info("init result : {}",getConTask.getStatusInfo());
-		return !list.isEmpty();
     }
     
 	public void doHeartbeat() {
@@ -193,6 +186,14 @@ public class MySQLMetaBean {
 
 	public DBHeartbeat getHeartbeat() {
 		return heartbeat;
+	}
+
+	public int getIndex() {
+		return index;
+	}
+
+	public void setIndex(int index) {
+		this.index = index;
 	}
 
 	/**

--- a/source/src/main/java/io/mycat/mycat2/beans/heartbeat/MySQLHeartbeat.java
+++ b/source/src/main/java/io/mycat/mycat2/beans/heartbeat/MySQLHeartbeat.java
@@ -200,7 +200,7 @@ public class MySQLHeartbeat extends DBHeartbeat {
 				this.errorCount = 0;
 		}
 		//当心跳成功，同时字符集未加载过，则加载字符集，如果是集群模式，需要通知集群加载字符集
-		if (this.status == OK_STATUS && MySQLMetaBean.charsetLoaded == false) {
+		if (this.status == OK_STATUS && source.charsetLoaded == false) {
 			try {
 			    ClusterConfig clusterConfig = ProxyRuntime.INSTANCE.getConfig().getConfig(ConfigEnum.CLUSTER);
 			    if (clusterConfig.getCluster().isEnable()) {

--- a/source/src/main/java/io/mycat/mycat2/beans/heartbeat/MySQLHeartbeat.java
+++ b/source/src/main/java/io/mycat/mycat2/beans/heartbeat/MySQLHeartbeat.java
@@ -200,7 +200,7 @@ public class MySQLHeartbeat extends DBHeartbeat {
 				this.errorCount = 0;
 		}
 		//当心跳成功，同时字符集未加载过，则加载字符集，如果是集群模式，需要通知集群加载字符集
-		if (this.status == OK_STATUS && !source.charsetLoaded) {
+		if (this.status == OK_STATUS && MySQLMetaBean.charsetLoaded == false) {
 			try {
 			    ClusterConfig clusterConfig = ProxyRuntime.INSTANCE.getConfig().getConfig(ConfigEnum.CLUSTER);
 			    if (clusterConfig.getCluster().isEnable()) {

--- a/source/src/main/java/io/mycat/mycat2/beans/heartbeat/MySQLHeartbeat.java
+++ b/source/src/main/java/io/mycat/mycat2/beans/heartbeat/MySQLHeartbeat.java
@@ -28,6 +28,8 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.concurrent.locks.ReentrantLock;
 
+import io.mycat.proxy.man.cmds.LeaderNotifyPacketCommand;
+import io.mycat.proxy.man.packet.LeaderNotifyPacket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -161,41 +163,50 @@ public class MySQLHeartbeat extends DBHeartbeat {
 	public void setResult(int result, MySQLDetector detector, String msg) {
 		this.isChecking.set(false);
 		switch (result) {
-		case OK_STATUS:
-			setOk(detector);
-			break;
-		case ERROR_STATUS:
-			setError(detector,msg);
-			break;
-		case TIMEOUT_STATUS:
-			setTimeout(detector);
-			break;
-		case ERROR_CONF: //配置错误时,停止心跳。
-			//TODO 配置错误,是否通知集群
-//			System.exit(0);
-			break;
+			case OK_STATUS:
+				setOk(detector);
+				break;
+			case ERROR_STATUS:
+				setError(detector,msg);
+				break;
+			case TIMEOUT_STATUS:
+				setTimeout(detector);
+				break;
+			case ERROR_CONF: //配置错误时,停止心跳。
+				//TODO 配置错误,是否通知集群
+	//			System.exit(0);
+				break;
 		}
 	}
 
 	private void setOk(MySQLDetector detector) {
 		switch (status) {
-		case DBHeartbeat.TIMEOUT_STATUS:
-			this.status = DBHeartbeat.INIT_STATUS;
-			this.errorCount = 0;
-			if (!isStop.get()) {
-				heartbeat();// timeout, heart beat again
+			case DBHeartbeat.TIMEOUT_STATUS:
+				this.status = DBHeartbeat.INIT_STATUS;
+				this.errorCount = 0;
+				if (!isStop.get()) {
+					heartbeat();// timeout, heart beat again
+				}
+				break;
+			case DBHeartbeat.INIT_STATUS:
+				logger.info("current repl status [INIT_STATUS ---> OK_STATUS]. update lastSwitchTime .{}:{}", source.getDsMetaBean().getIp(), source.getDsMetaBean().getPort());
+				MycatConfig conf = ProxyRuntime.INSTANCE.getConfig();
+				HeartbeatConfig heartbeatConfig = conf.getConfig(ConfigEnum.HEARTBEAT);
+				source.getRepBean().setLastSwitchTime(System.currentTimeMillis() - heartbeatConfig.getHeartbeat().getMinSwitchtimeInterval());
+			case DBHeartbeat.OK_STATUS:
+			default:
+				this.status = OK_STATUS;
+				this.errorCount = 0;
+		}
+		//todo 当心跳成功，同时字符集未加载过，则加载字符集，如果是集群模式，需要通知集群加载字符集
+		if (this.status == OK_STATUS && !source.charsetLoaded) {
+			try {
+				LeaderNotifyPacket pkg = new LeaderNotifyPacket(LeaderNotifyPacket.LOAD_CHARACTER, source.getRepBean().getReplicaBean().getName(), Integer.toString(source.getIndex()));
+				LeaderNotifyPacketCommand.INSTANCE.sendNotifyCmd(pkg);
+				source.init();
+			} catch (IOException e) {
+				logger.error("error to init datasource for MySQLMetaBean {}", source);
 			}
-			break;
-		case DBHeartbeat.INIT_STATUS:
-			logger.info("current repl status [INIT_STATUS ---> OK_STATUS ]. update lastSwitchTime .{}:{}", source.getDsMetaBean().getIp(), source.getDsMetaBean().getPort());
-			MycatConfig conf = ProxyRuntime.INSTANCE.getConfig();
-			HeartbeatConfig heartbeatConfig = conf.getConfig(ConfigEnum.HEARTBEAT);
-			source.getRepBean().setLastSwitchTime(System.currentTimeMillis() - heartbeatConfig.getHeartbeat().getMinSwitchtimeInterval());
-		case DBHeartbeat.OK_STATUS:
-		default:
-			this.status = OK_STATUS;
-			this.errorCount = 0;
-			
 		}
 	}
 

--- a/source/src/main/java/io/mycat/mycat2/tasks/BackendGetConnectionTask.java
+++ b/source/src/main/java/io/mycat/mycat2/tasks/BackendGetConnectionTask.java
@@ -10,14 +10,12 @@ import org.slf4j.LoggerFactory;
 import io.mycat.mycat2.MySQLSession;
 
 public class BackendGetConnectionTask implements AsynTaskCallBack<MySQLSession>{
-	
 	private final CopyOnWriteArrayList<MySQLSession> successCons;
 	private static final Logger logger = LoggerFactory.getLogger(BackendGetConnectionTask.class);
 	private final AtomicInteger finishedCount = new AtomicInteger(0);
 	private final int total;
 	
-	public BackendGetConnectionTask(CopyOnWriteArrayList<MySQLSession> connsToStore,
-			int totalNumber) {
+	public BackendGetConnectionTask(CopyOnWriteArrayList<MySQLSession> connsToStore, int totalNumber) {
 		this.successCons = connsToStore;
 		this.total = totalNumber;
 	}

--- a/source/src/main/java/io/mycat/proxy/man/AdminCommandResovler.java
+++ b/source/src/main/java/io/mycat/proxy/man/AdminCommandResovler.java
@@ -39,6 +39,9 @@ public class AdminCommandResovler {
 		adminCommandMap.put(ManagePacket.PKG_CONFIG_PREPARE, updateCommand);
 		adminCommandMap.put(ManagePacket.PKG_CONFIG_CONFIRM, updateCommand);
 		adminCommandMap.put(ManagePacket.PKG_CONFIG_COMMIT, updateCommand);
+
+		LeaderNotifyPacketCommand notifyCommand = LeaderNotifyPacketCommand.INSTANCE;
+		adminCommandMap.put(ManagePacket.PKG_LEADER_NOTIFY, notifyCommand);
 	}
 
 	public AdminCommand resolveCommand(byte pkgType) {

--- a/source/src/main/java/io/mycat/proxy/man/ManagePacket.java
+++ b/source/src/main/java/io/mycat/proxy/man/ManagePacket.java
@@ -32,6 +32,8 @@ public abstract class ManagePacket {
 	public static final byte PKG_CONFIG_CONFIRM = 11;
 	public static final byte PKG_CONFIG_COMMIT = 12;
 
+	public static final byte PKG_LEADER_NOTIFY = 13;
+
 	protected byte pkgType;
 	// 长度最长为2字节的short，即65535，长度包括包头3个字节在内
 	protected int pkgLength;

--- a/source/src/main/java/io/mycat/proxy/man/cmds/ClusterJoinPacketCommand.java
+++ b/source/src/main/java/io/mycat/proxy/man/cmds/ClusterJoinPacketCommand.java
@@ -2,9 +2,7 @@ package io.mycat.proxy.man.cmds;
 
 import java.io.IOException;
 
-import io.mycat.mycat2.ProxyStarter;
-import io.mycat.proxy.man.packet.ConfigVersionReqPacket;
-import io.mycat.proxy.man.packet.NodeRegInfoPacket;
+import io.mycat.proxy.man.packet.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,8 +12,6 @@ import io.mycat.proxy.man.AdminSession;
 import io.mycat.proxy.man.ClusterNode;
 import io.mycat.proxy.man.ManagePacket;
 import io.mycat.proxy.man.MyCluster.ClusterState;
-import io.mycat.proxy.man.packet.JoinCLusterAckPacket;
-import io.mycat.proxy.man.packet.JoinCLusterNotifyPacket;
 
 /**
  * 用来处理集群Jion报文的命令，
@@ -55,7 +51,6 @@ public class ClusterJoinPacketCommand implements AdminCommand {
 			if (theNode.getMyClusterState() != ClusterState.Clustered) {
 				theNode.setMyClusterState(ClusterState.Clustered, System.currentTimeMillis());
 			}
-
 		} else if (cmdType == ManagePacket.PKG_JOIN_NOTIFY_ClUSTER) {
 			logger.debug(" handler PKG_JOIN_NOTIFY_ClUSTER package. from {} ",session.getNodeId());
 			// leader 批准加入Cluster

--- a/source/src/main/java/io/mycat/proxy/man/cmds/ConfigUpdatePacketCommand.java
+++ b/source/src/main/java/io/mycat/proxy/man/cmds/ConfigUpdatePacketCommand.java
@@ -26,8 +26,6 @@ public class ConfigUpdatePacketCommand implements AdminCommand {
     public static final ConfigUpdatePacketCommand INSTANCE = new ConfigUpdatePacketCommand();
     private static final Logger LOGGER = LoggerFactory.getLogger(ConfigUpdatePacketCommand.class);
 
-    private ConfigUpdatePacketCommand() {}
-
     @Override
     public void handlerPkg(AdminSession session, byte cmdType) throws IOException {
         if (ProxyRuntime.INSTANCE.getMyCLuster().getClusterState() != MyCluster.ClusterState.Clustered) {

--- a/source/src/main/java/io/mycat/proxy/man/cmds/LeaderNotifyPacketCommand.java
+++ b/source/src/main/java/io/mycat/proxy/man/cmds/LeaderNotifyPacketCommand.java
@@ -1,0 +1,79 @@
+package io.mycat.proxy.man.cmds;
+
+import io.mycat.mycat2.beans.MySQLMetaBean;
+import io.mycat.mycat2.beans.MySQLRepBean;
+import io.mycat.mycat2.beans.heartbeat.DBHeartbeat;
+import io.mycat.proxy.ProxyRuntime;
+import io.mycat.proxy.man.*;
+import io.mycat.proxy.man.packet.LeaderNotifyPacket;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * Desc: 用来处理配置更新相关报文
+ *
+ * @date: 11/09/2017
+ * @author: gaozhiwen
+ */
+public class LeaderNotifyPacketCommand implements AdminCommand {
+    public static final LeaderNotifyPacketCommand INSTANCE = new LeaderNotifyPacketCommand();
+    private static final Logger LOGGER = LoggerFactory.getLogger(LeaderNotifyPacketCommand.class);
+
+    public void sendNotifyCmd(LeaderNotifyPacket pkg) {
+        ProxyRuntime.INSTANCE.getAdminSessionManager().getAllSessions().forEach(adminSession -> {
+            if (adminSession.isChannelOpen()) {
+                try {
+                    adminSession.answerClientNow(pkg);
+                } catch (Exception e) {
+                    LOGGER.warn("notify node err " + adminSession.getNodeId(), e);
+                }
+            }
+        });
+    }
+
+    @Override
+    public void handlerPkg(AdminSession session, byte cmdType) throws IOException {
+        if (ProxyRuntime.INSTANCE.getMyCLuster().getClusterState() != MyCluster.ClusterState.Clustered) {
+            LOGGER.warn("node is not clustered state, cluster may crashed, received older pkg, throw it");
+            return;
+        }
+
+        if (cmdType == ManagePacket.PKG_LEADER_NOTIFY) {
+            handleCmd(session);
+        } else {
+            LOGGER.warn("Maybe Bug, Leader us want you to fix it ");
+        }
+    }
+
+    /**
+     * 处理leader发送来的命令报文
+     * 
+     * @param session
+     */
+    private void handleCmd(AdminSession session) throws IOException {
+        LeaderNotifyPacket packet = new LeaderNotifyPacket();
+        packet.resolve(session.readingBuffer);
+        switch (packet.getType()) {
+            case LeaderNotifyPacket.LOAD_CHARACTER:
+                String repName = packet.getDetail();
+                int index = Integer.valueOf(packet.getAttach());
+                MySQLRepBean repBean = ProxyRuntime.INSTANCE.getConfig().getMySQLRepBean(repName);
+                if (repBean == null) {
+                    LOGGER.warn("leader packet repName may error, replica name: {}", repName);
+                    return;
+                }
+                MySQLMetaBean metaBean = repBean.getMetaBeans().get(index);
+                if (metaBean == null) {
+                    LOGGER.warn("leader packet index may error, index: {}", index);
+                    return;
+                }
+                metaBean.init();
+                metaBean.getHeartbeat().setStatus(DBHeartbeat.OK_STATUS);
+                break;
+            default:
+                LOGGER.warn("Maybe Bug, Leader us want you to fix it ");
+        }
+    }
+}

--- a/source/src/main/java/io/mycat/proxy/man/cmds/LeaderNotifyPacketCommand.java
+++ b/source/src/main/java/io/mycat/proxy/man/cmds/LeaderNotifyPacketCommand.java
@@ -21,16 +21,19 @@ public class LeaderNotifyPacketCommand implements AdminCommand {
     public static final LeaderNotifyPacketCommand INSTANCE = new LeaderNotifyPacketCommand();
     private static final Logger LOGGER = LoggerFactory.getLogger(LeaderNotifyPacketCommand.class);
 
-    public void sendNotifyCmd(LeaderNotifyPacket pkg) {
-        ProxyRuntime.INSTANCE.getAdminSessionManager().getAllSessions().forEach(adminSession -> {
-            if (adminSession.isChannelOpen()) {
-                try {
-                    adminSession.answerClientNow(pkg);
-                } catch (Exception e) {
-                    LOGGER.warn("notify node err " + adminSession.getNodeId(), e);
-                }
+    public void sendNotifyCmd(LeaderNotifyPacket pkg, AdminSession adminSession) {
+        if (adminSession.isChannelOpen()) {
+            try {
+                adminSession.answerClientNow(pkg);
+            } catch (Exception e) {
+                LOGGER.warn("notify node err " + adminSession.getNodeId(), e);
             }
-        });
+        }
+    }
+
+    public void sendNotifyCmd(LeaderNotifyPacket pkg) {
+        ProxyRuntime.INSTANCE.getAdminSessionManager().getAllSessions()
+                .forEach(adminSession -> sendNotifyCmd(pkg, adminSession));
     }
 
     @Override

--- a/source/src/main/java/io/mycat/proxy/man/packet/ConfigReqPacket.java
+++ b/source/src/main/java/io/mycat/proxy/man/packet/ConfigReqPacket.java
@@ -17,6 +17,12 @@ public class ConfigReqPacket extends ManagePacket {
         super(ManagePacket.PKG_CONFIG_REQ);
     }
 
+    public ConfigReqPacket(int confCount, byte[] confTypes) {
+        this();
+        this.confCount = confCount;
+        this.confTypes = confTypes;
+    }
+
     @Override
     public void resolveBody(ProxyBuffer buffer) {
         confCount = (int) buffer.readFixInt(4);

--- a/source/src/main/java/io/mycat/proxy/man/packet/LeaderNotifyPacket.java
+++ b/source/src/main/java/io/mycat/proxy/man/packet/LeaderNotifyPacket.java
@@ -1,0 +1,67 @@
+package io.mycat.proxy.man.packet;
+
+import io.mycat.proxy.ProxyBuffer;
+import io.mycat.proxy.man.ManagePacket;
+
+/**
+ * Desc: 主节点向从节点发送通知的报文
+ *
+ * @date: 11/09/2017
+ * @author: gaozhiwen
+ */
+public class LeaderNotifyPacket extends ManagePacket {
+    public static final byte LOAD_CHARACTER = 1;
+
+    private byte type;
+    private String detail;
+    private String attach;
+
+    public LeaderNotifyPacket() {
+        super(ManagePacket.PKG_LEADER_NOTIFY);
+    }
+
+    public LeaderNotifyPacket(byte type, String detail, String attach) {
+        super(ManagePacket.PKG_LEADER_NOTIFY);
+        this.type = type;
+        this.detail = detail;
+        this.attach = attach;
+    }
+
+    @Override
+    public void resolveBody(ProxyBuffer buffer) {
+        this.type = buffer.readByte();
+        this.detail = buffer.readNULString();
+        this.attach = buffer.readNULString();
+    }
+
+    @Override
+    public void writeBody(ProxyBuffer buffer) {
+        buffer.writeByte(type);
+        buffer.writeNULString(detail);
+        buffer.writeNULString(attach);
+    }
+
+    public byte getType() {
+        return type;
+    }
+
+    public void setType(byte type) {
+        this.type = type;
+    }
+
+    public String getDetail() {
+        return detail;
+    }
+
+    public void setDetail(String detail) {
+        this.detail = detail;
+    }
+
+    public String getAttach() {
+        return attach;
+    }
+
+    public void setAttach(String attach) {
+        this.attach = attach;
+    }
+}


### PR DESCRIPTION
调整字符集加载的顺序，修复mycat先启，mysql后启时字符集加载不上的问题
处理方案：
把MySQLMetaBean的初始化状态设置为INIT，当心跳检测成功之后，根据是否集群做不同处理
非集群下直接初始化后端连接，加载字符集
集群下主节点初始化后端连接，加载字符集，同时通知从节点初始化该metaBean的后端连接，从节点加载完成之后设置状态为OK