### PR TITLE
修复 win 下启动mycat 报 directMemory 溢出问题

### DIFF
--- a/source/src/main/java/io/mycat/mycat2/ProxyStarter.java
+++ b/source/src/main/java/io/mycat/mycat2/ProxyStarter.java
@@ -20,6 +20,7 @@ import io.mycat.proxy.buffer.DirectByteBufferPool;
 import io.mycat.proxy.man.AdminCommandResovler;
 import io.mycat.proxy.man.ClusterNode;
 import io.mycat.proxy.man.MyCluster;
+import javafx.application.Platform;
 
 public class ProxyStarter {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ProxyStarter.class);
@@ -124,13 +125,10 @@ public class ProxyStarter {
 		// Mycat 2.0 Session Manager
 		MycatReactorThread[] nioThreads = (MycatReactorThread[]) MycatRuntime.INSTANCE.getReactorThreads();
 		ProxyConfig proxyConfig = ProxyRuntime.INSTANCE.getConfig().getConfig(ConfigEnum.PROXY);
-		ProxyBean proxybean = proxyConfig.getProxy();
 		int cpus = nioThreads.length;
+		
 		for (int i = 0; i < cpus; i++) {
-			MycatReactorThread thread = new MycatReactorThread(
-					new DirectByteBufferPool(proxybean.getBufferPoolPageSize(),
-							proxybean.getBufferPoolChunkSize(),
-							proxybean.getBufferPoolPageNumber()));
+			MycatReactorThread thread = new MycatReactorThread(ProxyRuntime.INSTANCE.getBufferPoolFactory().getBufferPool());
 			thread.setName("NIO_Thread " + (i + 1));
 			thread.start();
 			nioThreads[i] = thread;

--- a/source/src/main/java/io/mycat/mycat2/ProxyStarter.java
+++ b/source/src/main/java/io/mycat/mycat2/ProxyStarter.java
@@ -20,7 +20,6 @@ import io.mycat.proxy.buffer.DirectByteBufferPool;
 import io.mycat.proxy.man.AdminCommandResovler;
 import io.mycat.proxy.man.ClusterNode;
 import io.mycat.proxy.man.MyCluster;
-import javafx.application.Platform;
 
 public class ProxyStarter {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ProxyStarter.class);

--- a/source/src/main/java/io/mycat/proxy/ProxyRuntime.java
+++ b/source/src/main/java/io/mycat/proxy/ProxyRuntime.java
@@ -14,7 +14,6 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,14 +25,13 @@ import io.mycat.mycat2.MycatConfig;
 import io.mycat.mycat2.beans.MySQLRepBean;
 import io.mycat.mycat2.beans.conf.ClusterConfig;
 import io.mycat.mycat2.beans.conf.HeartbeatConfig;
-import io.mycat.mycat2.beans.conf.ReplicaBean.RepTypeEnum;
 import io.mycat.mycat2.beans.conf.ReplicaIndexConfig;
 import io.mycat.mycat2.common.ExecutorUtil;
 import io.mycat.mycat2.common.NameableExecutor;
 import io.mycat.mycat2.loadbalance.LBSession;
-import io.mycat.mycat2.loadbalance.LoadBalanceStrategy;
 import io.mycat.mycat2.loadbalance.ProxySession;
 import io.mycat.mycat2.sqlparser.MatchMethodGenerator;
+import io.mycat.proxy.buffer.BufferPooLFactory;
 import io.mycat.proxy.man.AdminCommandResovler;
 import io.mycat.proxy.man.AdminSession;
 import io.mycat.proxy.man.MyCluster;
@@ -83,6 +81,7 @@ public class ProxyRuntime {
 	private int catletClassCheckSeconds = 60;
 	/*动态加载catlet的classs*/
 	private DynaClassLoader catletLoader = null;
+	private BufferPooLFactory  bufferPoolFactory = null;
 
 	/**
 	 * 是否双向同时通信，大部分TCP Server是单向的，即发送命令，等待应答，然后下一个
@@ -112,6 +111,8 @@ public class ProxyRuntime {
 				+ File.separator + "catlet", catletClassCheckSeconds);
 		
 		heartbeatScheduler.scheduleAtFixedRate(updateTime(), 0L, TIME_UPDATE_PERIOD,TimeUnit.MILLISECONDS);
+		
+		bufferPoolFactory = new BufferPooLFactory(nioReactorThreads);
 	}
 	
 	public ProxyReactorThread<?> getProxyReactorThread(ReactorEnv reactorEnv){
@@ -390,5 +391,13 @@ public class ProxyRuntime {
 	
 	public DynaClassLoader getCatletLoader() {
 		return catletLoader;
+	}
+
+	public BufferPooLFactory getBufferPoolFactory() {
+		return bufferPoolFactory;
+	}
+
+	public void setBufferPoolFactory(BufferPooLFactory bufferPoolFactory) {
+		this.bufferPoolFactory = bufferPoolFactory;
 	}
 }

--- a/source/src/main/java/io/mycat/proxy/ProxyRuntime.java
+++ b/source/src/main/java/io/mycat/proxy/ProxyRuntime.java
@@ -112,7 +112,7 @@ public class ProxyRuntime {
 		
 		heartbeatScheduler.scheduleAtFixedRate(updateTime(), 0L, TIME_UPDATE_PERIOD,TimeUnit.MILLISECONDS);
 		
-		bufferPoolFactory = new BufferPooLFactory(nioReactorThreads);
+		bufferPoolFactory = BufferPooLFactory.getInstance();
 	}
 	
 	public ProxyReactorThread<?> getProxyReactorThread(ReactorEnv reactorEnv){

--- a/source/src/main/java/io/mycat/proxy/buffer/BufferPooLFactory.java
+++ b/source/src/main/java/io/mycat/proxy/buffer/BufferPooLFactory.java
@@ -1,0 +1,84 @@
+package io.mycat.proxy.buffer;
+
+import java.security.InvalidParameterException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.mycat.mycat2.beans.conf.ProxyBean;
+import io.mycat.mycat2.beans.conf.ProxyConfig;
+import io.mycat.proxy.ConfigEnum;
+import io.mycat.proxy.ProxyRuntime;
+
+/**
+ * bufferpool 分配器
+ * @author yanjunli
+ *
+ */
+public class BufferPooLFactory {
+	
+	private static final Logger logger = LoggerFactory.getLogger(BufferPooLFactory.class);
+	
+    public final  static double DIRECT_SAFETY_FRACTION  = 0.7;
+	
+	private ProxyBean proxybean;
+	
+	private List<BufferPool> bufferPools = new ArrayList<>();
+		
+	public BufferPooLFactory(int poolnum){
+		
+		ProxyConfig proxyConfig = ProxyRuntime.INSTANCE.getConfig().getConfig(ConfigEnum.PROXY);
+		
+		proxybean = proxyConfig.getProxy();
+		
+		long directMemorySize = (long)(Platform.getMaxDirectMemory()*DIRECT_SAFETY_FRACTION);
+		
+		int expectPoolSize = Double.valueOf(directMemorySize / poolnum).intValue();
+		
+		short bufferPoolPageNumber = proxybean.getBufferPoolPageNumber();
+		
+		int bufferPoolPageSize = proxybean.getBufferPoolPageSize();
+		
+		int poolsize = bufferPoolPageNumber * bufferPoolPageSize;
+		
+		if(expectPoolSize < poolsize){
+			logger.warn("max directMemory is {}",directMemorySize);
+			logger.warn("bufferPoolPageNumber * bufferPoolPageSize > expectPoolSize. "
+					+ "bufferPoolPageNumber is {},bufferPoolPageSize is {},expectPoolSize is {} "
+					+ "please check it!!!!",bufferPoolPageNumber,bufferPoolPageSize,expectPoolSize);
+			
+			logger.warn("try reset bufferPool settings ");
+			if(directMemorySize < bufferPoolPageSize * poolnum ){
+				throw new InvalidParameterException("directMemorySize  is too small!!!. min {"+bufferPoolPageSize * poolnum+"}");
+			}
+			
+			bufferPoolPageNumber = Double.valueOf(expectPoolSize / bufferPoolPageSize).shortValue();
+			logger.info("reset bufferPoolPageNumber to {}",bufferPoolPageNumber);
+			proxybean.setBufferPoolPageNumber(bufferPoolPageNumber);
+		}
+		
+		IntStream.range(0, poolnum).forEach(f->{
+			bufferPools.add(new DirectByteBufferPool(proxybean.getBufferPoolPageSize(),
+					proxybean.getBufferPoolChunkSize(),
+					proxybean.getBufferPoolPageNumber()));
+		});
+	}
+	
+	/**
+	 * 正常情况，不会有并发
+	 * @return
+	 */
+	public synchronized BufferPool getBufferPool(){
+		if(bufferPools.size()==0){
+			throw new InvalidParameterException("bufferPool is empty. maybe a bug,please fix it!!!!!");
+		}
+		return bufferPools.remove(bufferPools.size()-1);
+	}
+	
+	public synchronized void recycle(BufferPool pool){
+		bufferPools.add(pool);
+	}
+}

--- a/source/src/main/java/io/mycat/proxy/buffer/Platform.java
+++ b/source/src/main/java/io/mycat/proxy/buffer/Platform.java
@@ -1,0 +1,390 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mycat.proxy.buffer;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import sun.misc.Cleaner;
+import sun.misc.Unsafe;
+
+public final class Platform {
+
+    private final static Logger logger = LoggerFactory.getLogger(Platform.class);
+    private static final Pattern MAX_DIRECT_MEMORY_SIZE_ARG_PATTERN =
+            Pattern.compile("\\s*-XX:MaxDirectMemorySize\\s*=\\s*([0-9]+)\\s*([kKmMgG]?)\\s*$");
+    private static final Unsafe _UNSAFE;
+
+    public static final int BYTE_ARRAY_OFFSET;
+
+    public static final int SHORT_ARRAY_OFFSET;
+
+    public static final int INT_ARRAY_OFFSET;
+
+    public static final int LONG_ARRAY_OFFSET;
+
+    public static final int FLOAT_ARRAY_OFFSET;
+
+    public static final int DOUBLE_ARRAY_OFFSET;
+
+    private static final long MAX_DIRECT_MEMORY;
+
+    private static final boolean unaligned;
+
+    public static final boolean littleEndian = ByteOrder.nativeOrder()
+            .equals(ByteOrder.LITTLE_ENDIAN);
+
+    static {
+        boolean _unaligned;
+        // use reflection to access unaligned field
+        try {
+            Class<?> bitsClass =
+                    Class.forName("java.nio.Bits", false, ClassLoader.getSystemClassLoader());
+            Method unalignedMethod = bitsClass.getDeclaredMethod("unaligned");
+            unalignedMethod.setAccessible(true);
+            _unaligned = Boolean.TRUE.equals(unalignedMethod.invoke(null));
+        } catch (Throwable t) {
+            // We at least know x86 and x64 support unaligned access.
+            String arch = System.getProperty("os.arch", "");
+            //noinspection DynamicRegexReplaceableByCompiledPattern
+            _unaligned = arch.matches("^(i[3-6]86|x86(_64)?|x64|amd64)$");
+        }
+        unaligned = _unaligned;
+        MAX_DIRECT_MEMORY = maxDirectMemory();
+
+    }
+
+
+    private static ClassLoader getSystemClassLoader() {
+        return System.getSecurityManager() == null ? ClassLoader.getSystemClassLoader() : (ClassLoader) AccessController.doPrivileged(new PrivilegedAction() {
+            public ClassLoader run() {
+                return ClassLoader.getSystemClassLoader();
+            }
+        });
+    }
+
+    /**
+     * GET  MaxDirectMemory Size,from Netty Project!
+     */
+    private static long maxDirectMemory() {
+        long maxDirectMemory = 0L;
+        Class t;
+        try {
+            t = Class.forName("sun.misc.VM", true, getSystemClassLoader());
+            Method runtimeClass = t.getDeclaredMethod("maxDirectMemory", new Class[0]);
+            maxDirectMemory = ((Number) runtimeClass.invoke((Object) null, new Object[0])).longValue();
+        } catch (Throwable var8) {
+            ;
+        }
+
+        if (maxDirectMemory > 0L) {
+            return maxDirectMemory;
+        } else {
+            try {
+                t = Class.forName("java.lang.management.ManagementFactory", true, getSystemClassLoader());
+                Class var10 = Class.forName("java.lang.management.RuntimeMXBean", true, getSystemClassLoader());
+                Object runtime = t.getDeclaredMethod("getRuntimeMXBean", new Class[0]).invoke((Object) null, new Object[0]);
+                List vmArgs = (List) var10.getDeclaredMethod("getInputArguments", new Class[0]).invoke(runtime, new Object[0]);
+
+                label41:
+                for (int i = vmArgs.size() - 1; i >= 0; --i) {
+                    Matcher m = MAX_DIRECT_MEMORY_SIZE_ARG_PATTERN.matcher((CharSequence) vmArgs.get(i));
+                    if (m.matches()) {
+                        maxDirectMemory = Long.parseLong(m.group(1));
+                        switch (m.group(2).charAt(0)) {
+                            case 'G':
+                            case 'g':
+                                maxDirectMemory *= 1073741824L;
+                                break label41;
+                            case 'K':
+                            case 'k':
+                                maxDirectMemory *= 1024L;
+                                break label41;
+                            case 'M':
+                            case 'm':
+                                maxDirectMemory *= 1048576L;
+                            default:
+                                break label41;
+                        }
+                    }
+                }
+            } catch (Throwable var9) {
+                logger.error(var9.getMessage());
+            }
+
+            if (maxDirectMemory <= 0L) {
+                maxDirectMemory = Runtime.getRuntime().maxMemory();
+                //System.out.println("maxDirectMemory: {} bytes (maybe)" + Long.valueOf(maxDirectMemory));
+            } else {
+                //System.out.println("maxDirectMemory: {} bytes" + Long.valueOf(maxDirectMemory));
+            }
+            return maxDirectMemory;
+        }
+    }
+
+    public static long getMaxDirectMemory() {
+        return MAX_DIRECT_MEMORY;
+    }
+
+    public static long getMaxHeapMemory() {
+        return Runtime.getRuntime().maxMemory();
+    }
+
+    /**
+     * @return true when running JVM is having sun's Unsafe package available in it and underlying
+     * system having unaligned-access capability.
+     */
+    public static boolean unaligned() {
+        return unaligned;
+    }
+
+    public static int getInt(Object object, long offset) {
+        return _UNSAFE.getInt(object, offset);
+    }
+
+    public static void putInt(Object object, long offset, int value) {
+        _UNSAFE.putInt(object, offset, value);
+    }
+
+    public static boolean getBoolean(Object object, long offset) {
+        return _UNSAFE.getBoolean(object, offset);
+    }
+
+    public static void putBoolean(Object object, long offset, boolean value) {
+        _UNSAFE.putBoolean(object, offset, value);
+    }
+
+    public static byte getByte(Object object, long offset) {
+        return _UNSAFE.getByte(object, offset);
+    }
+
+    public static void putByte(Object object, long offset, byte value) {
+        _UNSAFE.putByte(object, offset, value);
+    }
+
+    public static short getShort(Object object, long offset) {
+        return _UNSAFE.getShort(object, offset);
+    }
+
+    public static void putShort(Object object, long offset, short value) {
+        _UNSAFE.putShort(object, offset, value);
+    }
+
+    public static long getLong(Object object, long offset) {
+        return _UNSAFE.getLong(object, offset);
+    }
+
+    public static void putLong(Object object, long offset, long value) {
+        _UNSAFE.putLong(object, offset, value);
+    }
+
+    public static float getFloat(Object object, long offset) {
+        return _UNSAFE.getFloat(object, offset);
+    }
+
+    public static void putFloat(Object object, long offset, float value) {
+        _UNSAFE.putFloat(object, offset, value);
+    }
+
+    public static double getDouble(Object object, long offset) {
+        return _UNSAFE.getDouble(object, offset);
+    }
+
+    public static void putDouble(Object object, long offset, double value) {
+        _UNSAFE.putDouble(object, offset, value);
+    }
+
+
+    public static Object getObjectVolatile(Object object, long offset) {
+        return _UNSAFE.getObjectVolatile(object, offset);
+    }
+
+    public static void putObjectVolatile(Object object, long offset, Object value) {
+        _UNSAFE.putObjectVolatile(object, offset, value);
+    }
+
+    public static long allocateMemory(long size) {
+        return _UNSAFE.allocateMemory(size);
+    }
+
+    public static void freeMemory(long address) {
+        _UNSAFE.freeMemory(address);
+    }
+
+    public static long reallocateMemory(long address, long oldSize, long newSize) {
+        long newMemory = _UNSAFE.allocateMemory(newSize);
+        copyMemory(null, address, null, newMemory, oldSize);
+        freeMemory(address);
+        return newMemory;
+    }
+
+    /**
+     * Uses internal JDK APIs to allocate a DirectByteBuffer while ignoring the JVM's
+     * MaxDirectMemorySize limit (the default limit is too low and we do not want to require users
+     * to increase it).
+     */
+    @SuppressWarnings("unchecked")
+    public static ByteBuffer allocateDirectBuffer(int size) {
+        try {
+            Class cls = Class.forName("java.nio.DirectByteBuffer");
+            Constructor constructor = cls.getDeclaredConstructor(Long.TYPE, Integer.TYPE);
+            constructor.setAccessible(true);
+            Field cleanerField = cls.getDeclaredField("cleaner");
+            cleanerField.setAccessible(true);
+            final long memory = allocateMemory(size);
+            ByteBuffer buffer = (ByteBuffer) constructor.newInstance(memory, size);
+            Cleaner cleaner = Cleaner.create(buffer, new Runnable() {
+                @Override
+                public void run() {
+                    freeMemory(memory);
+                }
+            });
+            cleanerField.set(buffer, cleaner);
+            return buffer;
+        } catch (Exception e) {
+            throwException(e);
+        }
+        throw new IllegalStateException("unreachable");
+    }
+
+    public static void setMemory(long address, byte value, long size) {
+        _UNSAFE.setMemory(address, size, value);
+    }
+
+    public static void copyMemory(
+            Object src, long srcOffset, Object dst, long dstOffset, long length) {
+        // Check if dstOffset is before or after srcOffset to determine if we should copy
+        // forward or backwards. This is necessary in case src and dst overlap.
+        if (dstOffset < srcOffset) {
+            while (length > 0) {
+                long size = Math.min(length, UNSAFE_COPY_THRESHOLD);
+                _UNSAFE.copyMemory(src, srcOffset, dst, dstOffset, size);
+                length -= size;
+                srcOffset += size;
+                dstOffset += size;
+            }
+        } else {
+            srcOffset += length;
+            dstOffset += length;
+            while (length > 0) {
+                long size = Math.min(length, UNSAFE_COPY_THRESHOLD);
+                srcOffset -= size;
+                dstOffset -= size;
+                _UNSAFE.copyMemory(src, srcOffset, dst, dstOffset, size);
+                length -= size;
+            }
+
+        }
+    }
+
+    /**
+     * Raises an exception bypassing compiler checks for checked exceptions.
+     */
+    public static void throwException(Throwable t) {
+        _UNSAFE.throwException(t);
+    }
+
+    /**
+     * Limits the number of bytes to copy per {@link Unsafe#copyMemory(long, long, long)} to
+     * allow safepoint polling during a large copy.
+     */
+    private static final long UNSAFE_COPY_THRESHOLD = 1024L * 1024L;
+
+    static {
+        Unsafe unsafe;
+        try {
+            Field unsafeField = Unsafe.class.getDeclaredField("theUnsafe");
+            unsafeField.setAccessible(true);
+            unsafe = (Unsafe) unsafeField.get(null);
+        } catch (Throwable cause) {
+            unsafe = null;
+        }
+        _UNSAFE = unsafe;
+
+        if (_UNSAFE != null) {
+            BYTE_ARRAY_OFFSET = _UNSAFE.arrayBaseOffset(byte[].class);
+            SHORT_ARRAY_OFFSET = _UNSAFE.arrayBaseOffset(short[].class);
+            INT_ARRAY_OFFSET = _UNSAFE.arrayBaseOffset(int[].class);
+            LONG_ARRAY_OFFSET = _UNSAFE.arrayBaseOffset(long[].class);
+            FLOAT_ARRAY_OFFSET = _UNSAFE.arrayBaseOffset(float[].class);
+            DOUBLE_ARRAY_OFFSET = _UNSAFE.arrayBaseOffset(double[].class);
+        } else {
+            BYTE_ARRAY_OFFSET = 0;
+            SHORT_ARRAY_OFFSET = 0;
+            INT_ARRAY_OFFSET = 0;
+            LONG_ARRAY_OFFSET = 0;
+            FLOAT_ARRAY_OFFSET = 0;
+            DOUBLE_ARRAY_OFFSET = 0;
+        }
+    }
+
+    public static long objectFieldOffset(Field field) {
+        return _UNSAFE.objectFieldOffset(field);
+    }
+
+    public static void putOrderedLong(Object object, long valueOffset, long initialValue) {
+        _UNSAFE.putOrderedLong(object, valueOffset, initialValue);
+    }
+
+    public static void putLongVolatile(Object object, long valueOffset, long value) {
+        _UNSAFE.putLongVolatile(object, valueOffset, value);
+    }
+
+    public static boolean compareAndSwapLong(Object object, long valueOffset, long expectedValue, long newValue) {
+        return _UNSAFE.compareAndSwapLong(object, valueOffset, expectedValue, newValue);
+    }
+
+    public static int arrayBaseOffset(Class aClass) {
+        return _UNSAFE.arrayBaseOffset(aClass);
+    }
+
+    public static int arrayIndexScale(Class aClass) {
+        return _UNSAFE.arrayIndexScale(aClass);
+    }
+
+    public static void putOrderedInt(Object availableBuffer, long bufferAddress, int flag) {
+        _UNSAFE.putOrderedInt(availableBuffer, bufferAddress, flag);
+    }
+
+    public static int getIntVolatile(Object availableBuffer, long bufferAddress) {
+        return _UNSAFE.getIntVolatile(availableBuffer, bufferAddress);
+    }
+
+    public static Object getObject(Object entries, long l) {
+        return _UNSAFE.getObject(entries, l);
+    }
+
+    public static char getChar(Object baseObj, long l) {
+        return _UNSAFE.getChar(baseObj, l);
+    }
+
+    public static void putChar(Object baseObj, long l, char value) {
+        _UNSAFE.putChar(baseObj, l, value);
+    }
+}

--- a/source/src/main/java/io/mycat/proxy/buffer/Platform.java
+++ b/source/src/main/java/io/mycat/proxy/buffer/Platform.java
@@ -17,71 +17,21 @@
 
 package io.mycat.proxy.buffer;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import sun.misc.Cleaner;
-import sun.misc.Unsafe;
 
 public final class Platform {
-
-    private final static Logger logger = LoggerFactory.getLogger(Platform.class);
-    private static final Pattern MAX_DIRECT_MEMORY_SIZE_ARG_PATTERN =
-            Pattern.compile("\\s*-XX:MaxDirectMemorySize\\s*=\\s*([0-9]+)\\s*([kKmMgG]?)\\s*$");
-    private static final Unsafe _UNSAFE;
-
-    public static final int BYTE_ARRAY_OFFSET;
-
-    public static final int SHORT_ARRAY_OFFSET;
-
-    public static final int INT_ARRAY_OFFSET;
-
-    public static final int LONG_ARRAY_OFFSET;
-
-    public static final int FLOAT_ARRAY_OFFSET;
-
-    public static final int DOUBLE_ARRAY_OFFSET;
-
+    
     private static final long MAX_DIRECT_MEMORY;
 
-    private static final boolean unaligned;
-
-    public static final boolean littleEndian = ByteOrder.nativeOrder()
-            .equals(ByteOrder.LITTLE_ENDIAN);
-
     static {
-        boolean _unaligned;
-        // use reflection to access unaligned field
-        try {
-            Class<?> bitsClass =
-                    Class.forName("java.nio.Bits", false, ClassLoader.getSystemClassLoader());
-            Method unalignedMethod = bitsClass.getDeclaredMethod("unaligned");
-            unalignedMethod.setAccessible(true);
-            _unaligned = Boolean.TRUE.equals(unalignedMethod.invoke(null));
-        } catch (Throwable t) {
-            // We at least know x86 and x64 support unaligned access.
-            String arch = System.getProperty("os.arch", "");
-            //noinspection DynamicRegexReplaceableByCompiledPattern
-            _unaligned = arch.matches("^(i[3-6]86|x86(_64)?|x64|amd64)$");
-        }
-        unaligned = _unaligned;
         MAX_DIRECT_MEMORY = maxDirectMemory();
-
     }
 
 
-    private static ClassLoader getSystemClassLoader() {
+    @SuppressWarnings("unchecked")
+	private static ClassLoader getSystemClassLoader() {
         return System.getSecurityManager() == null ? ClassLoader.getSystemClassLoader() : (ClassLoader) AccessController.doPrivileged(new PrivilegedAction() {
             public ClassLoader run() {
                 return ClassLoader.getSystemClassLoader();
@@ -90,11 +40,13 @@ public final class Platform {
     }
 
     /**
-     * GET  MaxDirectMemory Size,from Netty Project!
+     * GET  MaxDirectMemory Size
      */
-    private static long maxDirectMemory() {
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+	private static long maxDirectMemory() {
         long maxDirectMemory = 0L;
         Class t;
+        
         try {
             t = Class.forName("sun.misc.VM", true, getSystemClassLoader());
             Method runtimeClass = t.getDeclaredMethod("maxDirectMemory", new Class[0]);
@@ -102,289 +54,10 @@ public final class Platform {
         } catch (Throwable var8) {
             ;
         }
-
-        if (maxDirectMemory > 0L) {
-            return maxDirectMemory;
-        } else {
-            try {
-                t = Class.forName("java.lang.management.ManagementFactory", true, getSystemClassLoader());
-                Class var10 = Class.forName("java.lang.management.RuntimeMXBean", true, getSystemClassLoader());
-                Object runtime = t.getDeclaredMethod("getRuntimeMXBean", new Class[0]).invoke((Object) null, new Object[0]);
-                List vmArgs = (List) var10.getDeclaredMethod("getInputArguments", new Class[0]).invoke(runtime, new Object[0]);
-
-                label41:
-                for (int i = vmArgs.size() - 1; i >= 0; --i) {
-                    Matcher m = MAX_DIRECT_MEMORY_SIZE_ARG_PATTERN.matcher((CharSequence) vmArgs.get(i));
-                    if (m.matches()) {
-                        maxDirectMemory = Long.parseLong(m.group(1));
-                        switch (m.group(2).charAt(0)) {
-                            case 'G':
-                            case 'g':
-                                maxDirectMemory *= 1073741824L;
-                                break label41;
-                            case 'K':
-                            case 'k':
-                                maxDirectMemory *= 1024L;
-                                break label41;
-                            case 'M':
-                            case 'm':
-                                maxDirectMemory *= 1048576L;
-                            default:
-                                break label41;
-                        }
-                    }
-                }
-            } catch (Throwable var9) {
-                logger.error(var9.getMessage());
-            }
-
-            if (maxDirectMemory <= 0L) {
-                maxDirectMemory = Runtime.getRuntime().maxMemory();
-                //System.out.println("maxDirectMemory: {} bytes (maybe)" + Long.valueOf(maxDirectMemory));
-            } else {
-                //System.out.println("maxDirectMemory: {} bytes" + Long.valueOf(maxDirectMemory));
-            }
-            return maxDirectMemory;
-        }
+        return maxDirectMemory;
     }
 
     public static long getMaxDirectMemory() {
         return MAX_DIRECT_MEMORY;
-    }
-
-    public static long getMaxHeapMemory() {
-        return Runtime.getRuntime().maxMemory();
-    }
-
-    /**
-     * @return true when running JVM is having sun's Unsafe package available in it and underlying
-     * system having unaligned-access capability.
-     */
-    public static boolean unaligned() {
-        return unaligned;
-    }
-
-    public static int getInt(Object object, long offset) {
-        return _UNSAFE.getInt(object, offset);
-    }
-
-    public static void putInt(Object object, long offset, int value) {
-        _UNSAFE.putInt(object, offset, value);
-    }
-
-    public static boolean getBoolean(Object object, long offset) {
-        return _UNSAFE.getBoolean(object, offset);
-    }
-
-    public static void putBoolean(Object object, long offset, boolean value) {
-        _UNSAFE.putBoolean(object, offset, value);
-    }
-
-    public static byte getByte(Object object, long offset) {
-        return _UNSAFE.getByte(object, offset);
-    }
-
-    public static void putByte(Object object, long offset, byte value) {
-        _UNSAFE.putByte(object, offset, value);
-    }
-
-    public static short getShort(Object object, long offset) {
-        return _UNSAFE.getShort(object, offset);
-    }
-
-    public static void putShort(Object object, long offset, short value) {
-        _UNSAFE.putShort(object, offset, value);
-    }
-
-    public static long getLong(Object object, long offset) {
-        return _UNSAFE.getLong(object, offset);
-    }
-
-    public static void putLong(Object object, long offset, long value) {
-        _UNSAFE.putLong(object, offset, value);
-    }
-
-    public static float getFloat(Object object, long offset) {
-        return _UNSAFE.getFloat(object, offset);
-    }
-
-    public static void putFloat(Object object, long offset, float value) {
-        _UNSAFE.putFloat(object, offset, value);
-    }
-
-    public static double getDouble(Object object, long offset) {
-        return _UNSAFE.getDouble(object, offset);
-    }
-
-    public static void putDouble(Object object, long offset, double value) {
-        _UNSAFE.putDouble(object, offset, value);
-    }
-
-
-    public static Object getObjectVolatile(Object object, long offset) {
-        return _UNSAFE.getObjectVolatile(object, offset);
-    }
-
-    public static void putObjectVolatile(Object object, long offset, Object value) {
-        _UNSAFE.putObjectVolatile(object, offset, value);
-    }
-
-    public static long allocateMemory(long size) {
-        return _UNSAFE.allocateMemory(size);
-    }
-
-    public static void freeMemory(long address) {
-        _UNSAFE.freeMemory(address);
-    }
-
-    public static long reallocateMemory(long address, long oldSize, long newSize) {
-        long newMemory = _UNSAFE.allocateMemory(newSize);
-        copyMemory(null, address, null, newMemory, oldSize);
-        freeMemory(address);
-        return newMemory;
-    }
-
-    /**
-     * Uses internal JDK APIs to allocate a DirectByteBuffer while ignoring the JVM's
-     * MaxDirectMemorySize limit (the default limit is too low and we do not want to require users
-     * to increase it).
-     */
-    @SuppressWarnings("unchecked")
-    public static ByteBuffer allocateDirectBuffer(int size) {
-        try {
-            Class cls = Class.forName("java.nio.DirectByteBuffer");
-            Constructor constructor = cls.getDeclaredConstructor(Long.TYPE, Integer.TYPE);
-            constructor.setAccessible(true);
-            Field cleanerField = cls.getDeclaredField("cleaner");
-            cleanerField.setAccessible(true);
-            final long memory = allocateMemory(size);
-            ByteBuffer buffer = (ByteBuffer) constructor.newInstance(memory, size);
-            Cleaner cleaner = Cleaner.create(buffer, new Runnable() {
-                @Override
-                public void run() {
-                    freeMemory(memory);
-                }
-            });
-            cleanerField.set(buffer, cleaner);
-            return buffer;
-        } catch (Exception e) {
-            throwException(e);
-        }
-        throw new IllegalStateException("unreachable");
-    }
-
-    public static void setMemory(long address, byte value, long size) {
-        _UNSAFE.setMemory(address, size, value);
-    }
-
-    public static void copyMemory(
-            Object src, long srcOffset, Object dst, long dstOffset, long length) {
-        // Check if dstOffset is before or after srcOffset to determine if we should copy
-        // forward or backwards. This is necessary in case src and dst overlap.
-        if (dstOffset < srcOffset) {
-            while (length > 0) {
-                long size = Math.min(length, UNSAFE_COPY_THRESHOLD);
-                _UNSAFE.copyMemory(src, srcOffset, dst, dstOffset, size);
-                length -= size;
-                srcOffset += size;
-                dstOffset += size;
-            }
-        } else {
-            srcOffset += length;
-            dstOffset += length;
-            while (length > 0) {
-                long size = Math.min(length, UNSAFE_COPY_THRESHOLD);
-                srcOffset -= size;
-                dstOffset -= size;
-                _UNSAFE.copyMemory(src, srcOffset, dst, dstOffset, size);
-                length -= size;
-            }
-
-        }
-    }
-
-    /**
-     * Raises an exception bypassing compiler checks for checked exceptions.
-     */
-    public static void throwException(Throwable t) {
-        _UNSAFE.throwException(t);
-    }
-
-    /**
-     * Limits the number of bytes to copy per {@link Unsafe#copyMemory(long, long, long)} to
-     * allow safepoint polling during a large copy.
-     */
-    private static final long UNSAFE_COPY_THRESHOLD = 1024L * 1024L;
-
-    static {
-        Unsafe unsafe;
-        try {
-            Field unsafeField = Unsafe.class.getDeclaredField("theUnsafe");
-            unsafeField.setAccessible(true);
-            unsafe = (Unsafe) unsafeField.get(null);
-        } catch (Throwable cause) {
-            unsafe = null;
-        }
-        _UNSAFE = unsafe;
-
-        if (_UNSAFE != null) {
-            BYTE_ARRAY_OFFSET = _UNSAFE.arrayBaseOffset(byte[].class);
-            SHORT_ARRAY_OFFSET = _UNSAFE.arrayBaseOffset(short[].class);
-            INT_ARRAY_OFFSET = _UNSAFE.arrayBaseOffset(int[].class);
-            LONG_ARRAY_OFFSET = _UNSAFE.arrayBaseOffset(long[].class);
-            FLOAT_ARRAY_OFFSET = _UNSAFE.arrayBaseOffset(float[].class);
-            DOUBLE_ARRAY_OFFSET = _UNSAFE.arrayBaseOffset(double[].class);
-        } else {
-            BYTE_ARRAY_OFFSET = 0;
-            SHORT_ARRAY_OFFSET = 0;
-            INT_ARRAY_OFFSET = 0;
-            LONG_ARRAY_OFFSET = 0;
-            FLOAT_ARRAY_OFFSET = 0;
-            DOUBLE_ARRAY_OFFSET = 0;
-        }
-    }
-
-    public static long objectFieldOffset(Field field) {
-        return _UNSAFE.objectFieldOffset(field);
-    }
-
-    public static void putOrderedLong(Object object, long valueOffset, long initialValue) {
-        _UNSAFE.putOrderedLong(object, valueOffset, initialValue);
-    }
-
-    public static void putLongVolatile(Object object, long valueOffset, long value) {
-        _UNSAFE.putLongVolatile(object, valueOffset, value);
-    }
-
-    public static boolean compareAndSwapLong(Object object, long valueOffset, long expectedValue, long newValue) {
-        return _UNSAFE.compareAndSwapLong(object, valueOffset, expectedValue, newValue);
-    }
-
-    public static int arrayBaseOffset(Class aClass) {
-        return _UNSAFE.arrayBaseOffset(aClass);
-    }
-
-    public static int arrayIndexScale(Class aClass) {
-        return _UNSAFE.arrayIndexScale(aClass);
-    }
-
-    public static void putOrderedInt(Object availableBuffer, long bufferAddress, int flag) {
-        _UNSAFE.putOrderedInt(availableBuffer, bufferAddress, flag);
-    }
-
-    public static int getIntVolatile(Object availableBuffer, long bufferAddress) {
-        return _UNSAFE.getIntVolatile(availableBuffer, bufferAddress);
-    }
-
-    public static Object getObject(Object entries, long l) {
-        return _UNSAFE.getObject(entries, l);
-    }
-
-    public static char getChar(Object baseObj, long l) {
-        return _UNSAFE.getChar(baseObj, l);
-    }
-
-    public static void putChar(Object baseObj, long l, char value) {
-        _UNSAFE.putChar(baseObj, l, value);
     }
 }

--- a/source/src/main/resources/mycat.yml
+++ b/source/src/main/resources/mycat.yml
@@ -1,3 +1,6 @@
 proxy:
   ip: 0.0.0.0
   port: 8066
+  bufferPoolPageSize: 4194304     # 一页的大小，默认 1024*1024*4
+  bufferPoolChunkSize: 8192       # chunk 大小 ， 默认 1024*4*2 。 chunk 为bufferpool 分配的最小单元
+  bufferPoolPageNumber: 64        # 页数量. 默认 64


### PR DESCRIPTION
如果bufferpool 总大小  大于 Platform.getMaxDirectMemory() *0.7  。
则尝试进行一次动态调整。
最小值为 reactorthread数 * bufferPoolPageSize. 
如果小于最小值，程序报错退出，mycat无法启动。

bufferpool 涉及到三个参数，可以在 mycat.yml文件内，做调整。
bufferPoolPageSize:（一页的大小，默认值 `1024*1024*4`）
bufferPoolChunkSize:（chunk 的大小，chunk 为pool 最小分配单元，默认值 `1024*4*2`）
bufferPoolPageNumber: （pool 中页的数量，默认值 64）
