### PR TITLE
为BufferSQLParser补充单元测试用例

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 target
 /source/.classpath
 /source/.project
+.DS_Store

--- a/source/pom.xml
+++ b/source/pom.xml
@@ -435,6 +435,27 @@
 				</dependencies>
 
 			</plugin>
+			
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.7.9</version>
+				<executions>
+					<execution>
+						<id>pre-test</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>post-test</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 
 		</plugins>
 	</build>

--- a/source/src/main/java/io/mycat/mycat2/sqlparser/MatchMethodGenerator.java
+++ b/source/src/main/java/io/mycat/mycat2/sqlparser/MatchMethodGenerator.java
@@ -1,17 +1,18 @@
 package io.mycat.mycat2.sqlparser;
 
-//import com.alibaba.druid.sql.parser.Token;
-import javafx.util.Pair;
-
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
+
+//import com.alibaba.druid.sql.parser.Token;
+import javafx.util.Pair;
 
 /**
  * Created by Administrator on 2017/2/13 0013.
@@ -201,6 +202,14 @@ public class MatchMethodGenerator {
         }
         return hash;
     }
+    
+  static void genIntTokenHash(String... strArray) {
+    initShrinkCharTbl();
+    for (String str : strArray) {
+      System.out.format("The IntTokenHash Of '%-16s' = 0x%04x%04x;%n", str,
+          genHash2(str.toCharArray()) & 0xFFFF, str.length());
+    }
+  }
 
     static boolean cmp(char[] str1, char[] str2) {
         if (str1.length == str2.length) {
@@ -359,19 +368,20 @@ public class MatchMethodGenerator {
         }
     }
 
-    public static void main(String[] args) {
-        //isXXXTokenGenerator();
-        //skipXXXTokenGenerator();
-//        sqlKeyHastTest("sql_tokens.txt", s -> genHash(s.toCharArray()), 0x1FFL);
-//        sqlKeyHastTest("minimal_sql_tokens.txt", s -> (long)genHash2(s.toCharArray()), 0x1FL);
-//        sqlKeyHastTest("minimal_sql_tokens.txt", s -> genHash(s.toCharArray()), 0x3FL);
-//        run();
-//        test1();
-//        GenerateIntTokenHash("minimal_sql_tokens.txt");
-        GenerateLongTokenHash("sql_tokens.txt");
-//        initShrinkCharTbl();
-//        System.out.format("0x%xL;%n", genHash("dn1".toCharArray()));
+  public static void main(String[] args) {
+    // isXXXTokenGenerator();
+    // skipXXXTokenGenerator();
+    // sqlKeyHastTest("sql_tokens.txt", s -> genHash(s.toCharArray()), 0x1FFL);
+    // sqlKeyHastTest("minimal_sql_tokens.txt", s -> (long)genHash2(s.toCharArray()), 0x1FL);
+    // sqlKeyHastTest("minimal_sql_tokens.txt", s -> genHash(s.toCharArray()), 0x3FL);
+    // run();
+    // test1();
+    // GenerateIntTokenHash("minimal_sql_tokens.txt");
+    // GenerateLongTokenHash("sql_tokens.txt");
+    // initShrinkCharTbl();
+    // System.out.format("0x%xL;%n", genHash("dn1".toCharArray()));
 
-
-    }
+    genIntTokenHash("SQL_DELIMETER", ";", "*", "AS", "$", "TRUNCATE", "HIGH_PRIORITY",
+                "REPL_METABEAN_INDEX", "XML");
+  };
 }

--- a/source/src/test/java/io/mycat/mycat2/sqlparser/DCLSQLParseTest.java
+++ b/source/src/test/java/io/mycat/mycat2/sqlparser/DCLSQLParseTest.java
@@ -1,10 +1,11 @@
 package io.mycat.mycat2.sqlparser;
 
-import junit.framework.TestCase;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import junit.framework.TestCase;
 
 /**
  * Created by jamie on 2017/8/31.
@@ -180,7 +181,7 @@ public class DCLSQLParseTest extends TestCase {
     //    SQLParser parser;
     BufferSQLParser parser;
     BufferSQLContext context;
-    private static final Logger LOGGER = LoggerFactory.getLogger(TCLSQLParserTest.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DCLSQLParseTest.class);
 
     private void test(String t) {
         LOGGER.info(t);

--- a/source/src/test/java/io/mycat/mycat2/sqlparser/SQLParserWithByteArrayInterfaceTest.java
+++ b/source/src/test/java/io/mycat/mycat2/sqlparser/SQLParserWithByteArrayInterfaceTest.java
@@ -1,12 +1,17 @@
 package io.mycat.mycat2.sqlparser;
 
-import io.mycat.mycat2.sqlparser.SQLParseUtils.Tokenizer;
-import junit.framework.TestCase;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.IntStream;
+
 import org.junit.Before;
 import org.junit.Test;
 
-import java.nio.charset.StandardCharsets;
-import java.util.stream.IntStream;
+import io.mycat.mycat2.sqlparser.SQLParseUtils.Tokenizer;
+import io.mycat.mycat2.sqlparser.byteArrayInterface.ByteArrayInterface;
+import io.mycat.mycat2.sqlparser.byteArrayInterface.ByteBufferArray;
+import io.mycat.mycat2.sqlparser.byteArrayInterface.Tokenizer2;
+import junit.framework.TestCase;
 
 /**
  * Created by Kaiz on 2017/1/22.
@@ -120,6 +125,20 @@ public class SQLParserWithByteArrayInterfaceTest extends TestCase {
     }
 
     @Test
+    public void testPriorityUpdate() throws Exception {
+        String sql = "UPDATE LOW_PRIORITY tbl_A set name='kaiz' where name='nobody';";
+        parser.parse(sql.getBytes(), context);
+        assertEquals("tbl_A", context.getTableName(0));
+    }
+
+    @Test
+    public void testIgnoreUpdate() throws Exception {
+        String sql = "UPDATE IGNORE tbl_A set name='kaiz' where name='nobody';";
+        parser.parse(sql.getBytes(), context);
+        assertEquals("tbl_A", context.getTableName(0));
+    }
+
+    @Test
     public void testNormalDelete() throws Exception {
         String sql = "DELETE FROM tbl_A WHERE name='nobody';";
         parser.parse(sql.getBytes(), context);
@@ -149,6 +168,29 @@ public class SQLParserWithByteArrayInterfaceTest extends TestCase {
         parser.parse(sql.getBytes(), context);
         assertEquals(BufferSQLContext.INSERT_SQL, context.getSQLType());
         assertEquals("tbl_A", context.getTableName(0));
+    }
+
+    @Test
+    public void testDelayedInsert() throws Exception {
+        String sql = "INSERT DELAYED INTO tbl_A (`name`) VALUES ('kaiz');";
+        parser.parse(sql.getBytes(), context);
+        assertEquals(BufferSQLContext.INSERT_SQL, context.getSQLType());
+        assertEquals("tbl_A", context.getTableName(0));
+    }
+
+    @Test
+    public void testPriorityInsert() throws Exception {
+        String sql = "INSERT LOW_PRIORITY INTO tbl_A (`name`) VALUES ('kaiz');";
+        parser.parse(sql.getBytes(), context);
+        assertEquals(BufferSQLContext.INSERT_SQL, context.getSQLType());
+        assertEquals("tbl_A", context.getTableName(0));
+        assertEquals(context.getRealSQL(0), sql);
+
+        String sql2 = "INSERT HIGH_PRIORITY INTO tbl_B (`name`) VALUES ('kaiz');";
+        parser.parse(sql2.getBytes(), context);
+        assertEquals(BufferSQLContext.INSERT_SQL, context.getSQLType());
+        assertEquals("tbl_B", context.getTableName(0));
+        assertEquals(context.getRealSQL(0), sql2);
     }
 
     @Test
@@ -420,6 +462,7 @@ public class SQLParserWithByteArrayInterfaceTest extends TestCase {
         assertEquals(20, context.getSQLCount());
         context.setSQLIdx(19);
         assertEquals("tbl_A", context.getSQLTableName(0, 0));
+        assertEquals("tbl_S", context.getSQLTableName(18, 0));
         assertEquals("tbl_T", context.getSQLTableName(19, 0));
         assertEquals(BufferSQLContext.SELECT_SQL, context.getSQLType(18));
         assertEquals(BufferSQLContext.INSERT_SQL, context.getSQLType(19));
@@ -491,6 +534,15 @@ public class SQLParserWithByteArrayInterfaceTest extends TestCase {
     @Test
     public void testLoadDataSQL() throws Exception {
         String sql = "load data  low_priority infile \"/home/mark/data.sql\" replace into table tbl_A;";
+        parser.parse(sql.getBytes(), context);
+        assertEquals(BufferSQLContext.LOAD_SQL, context.getSQLType());
+        assertEquals("tbl_A", context.getTableName(0));
+    }
+
+    @Test
+    public void testLoadXMLSQL() throws Exception {
+        String sql =
+                "load xml concurrent local infile \"/home/mark/data.xml\" ignore into table tbl_A;";
         parser.parse(sql.getBytes(), context);
         assertEquals(BufferSQLContext.LOAD_SQL, context.getSQLType());
         assertEquals("tbl_A", context.getTableName(0));
@@ -573,6 +625,40 @@ public class SQLParserWithByteArrayInterfaceTest extends TestCase {
         assertEquals(FunctionHash.VERSION, context.getSelectItem(0));
         assertEquals(FunctionHash.USER, context.getSelectItem(1));
         assertEquals(FunctionHash.DATABASE, context.getSelectItem(2));
+    }
+
+    @Test
+    public void testKill() throws Exception {
+        String sql = "kill 19201";
+        parser.parse(sql.getBytes(), context);
+        assertEquals(BufferSQLContext.KILL_SQL, context.getSQLType());
+
+        sql = "kill query 19201";
+        parser.parse(sql.getBytes(), context);
+        assertEquals(BufferSQLContext.KILL_QUERY_SQL, context.getSQLType());
+
+        sql = "kill connection 19201";
+        parser.parse(sql.getBytes(), context);
+        assertEquals(BufferSQLContext.KILL_SQL, context.getSQLType());
+    }
+
+    @Test
+    public void testHelp() throws Exception {
+        String sql = "help 'load data'";
+        parser.parse(ByteBuffer.wrap(sql.getBytes()), 0, sql.length(), context);
+        assertEquals(BufferSQLContext.HELP_SQL, context.getSQLType());
+        assertEquals(TokenHash.HELP, context.getTokenHash(0, 0));
+        assertEquals(Tokenizer2.STRINGS, context.getTokenType(0, 1));
+    }
+
+    @Test
+    public void testHelp2() throws Exception {
+        String sql = "help load data";
+        ByteArrayInterface src = new ByteBufferArray(sql.getBytes());
+        parser.parse(src, context);
+        assertEquals(BufferSQLContext.HELP_SQL, context.getSQLType());
+        assertEquals(TokenHash.HELP, context.getTokenHash(0, 0));
+        assertEquals(TokenHash.LOAD, context.getTokenHash(0, 1));
     }
 
     private static final String sql1 = "select t3.*,ztd3.TypeDetailName as UseStateName\n" +


### PR DESCRIPTION
1. pom.xml 增加jacoco 插件
2. 增加单元测试用例覆盖BufferSQLParser
3. .gitignore 忽略掉 macOS下的临时文件.DS_Store