### PR TITLE
引入AbstractBackendIOTask处理 dbinmultiserver 下的多节点的mysql后端的请求和响应

### DIFF
--- a/source/src/main/java/io/mycat/mycat2/MycatSession.java
+++ b/source/src/main/java/io/mycat/mycat2/MycatSession.java
@@ -1,5 +1,18 @@
 package io.mycat.mycat2;
 
+import java.io.IOException;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.SocketChannel;
+import java.security.InvalidParameterException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.mycat.mycat2.beans.MySQLMetaBean;
 import io.mycat.mycat2.beans.MySQLRepBean;
 import io.mycat.mycat2.beans.conf.DNBean;
@@ -23,18 +36,6 @@ import io.mycat.proxy.buffer.BufferPool;
 import io.mycat.util.ErrorCode;
 import io.mycat.util.ParseUtil;
 import io.mycat.util.RandomUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.nio.channels.SelectionKey;
-import java.nio.channels.Selector;
-import java.nio.channels.SocketChannel;
-import java.security.InvalidParameterException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
 
 /**
  * 前端连接会话
@@ -375,9 +376,10 @@ public class MycatSession extends AbstractMySQLSession {
             case ANNOTATION_ROUTE:
                 break;
             case DB_IN_MULTI_SERVER:
-                //在 DB_IN_MULTI_SERVER 模式中,如果不指定datanode以及Replica名字取得backendName,则使用默认的
+                // 在 DB_IN_MULTI_SERVER 模式中,如果不指定datanode以及Replica名字取得backendName,则使用默认的
                 backendName = ProxyRuntime.INSTANCE.getConfig().getMycatDataNodeMap()
                         .get(schema.getDefaultDataNode()).getReplica();
+                break;
             default:
                 break;
         }

--- a/source/src/main/java/io/mycat/mycat2/cmds/interceptor/SQLAnnotationChain.java
+++ b/source/src/main/java/io/mycat/mycat2/cmds/interceptor/SQLAnnotationChain.java
@@ -1,17 +1,18 @@
 package io.mycat.mycat2.cmds.interceptor;
 
-import io.mycat.mycat2.MySQLCommand;
-import io.mycat.mycat2.MycatSession;
-import io.mycat.mycat2.sqlannotations.AnnotationProcessor;
-import io.mycat.mycat2.sqlannotations.SQLAnnotation;
-import io.mycat.mycat2.sqlparser.BufferSQLContext;
-
 import java.security.InvalidParameterException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import io.mycat.mycat2.MySQLCommand;
+import io.mycat.mycat2.MycatSession;
+import io.mycat.mycat2.cmds.multinode.DbInMultiServerCmd;
+import io.mycat.mycat2.sqlannotations.AnnotationProcessor;
+import io.mycat.mycat2.sqlannotations.SQLAnnotation;
+import io.mycat.mycat2.sqlparser.BufferSQLContext;
 
 public class SQLAnnotationChain {
 	
@@ -56,11 +57,11 @@ public class SQLAnnotationChain {
             case DB_IN_ONE_SERVER:
                 break;
             case DB_IN_MULTI_SERVER:
-//                if (session.curRouteResultset != null
-//                        && session.curRouteResultset.getNodes().length > 1) {
-//                    // DB_IN_MULTI_SERVER 模式下
-//                    this.target = DbInMultiServerCmd.INSTANCE;
-//                }
+                if (session.getCurRouteResultset() != null
+                        && session.getCurRouteResultset().getNodes().length > 1) {
+                    // DB_IN_MULTI_SERVER 模式下
+                    this.target = DbInMultiServerCmd.INSTANCE;
+                }
                 break;
             case ANNOTATION_ROUTE:
                 break;

--- a/source/src/main/java/io/mycat/mycat2/cmds/multinode/DbInMultiServerCmd.java
+++ b/source/src/main/java/io/mycat/mycat2/cmds/multinode/DbInMultiServerCmd.java
@@ -1,26 +1,22 @@
 package io.mycat.mycat2.cmds.multinode;
 
-import io.mycat.mycat2.MySQLSession;
-import io.mycat.mycat2.MycatSession;
-import io.mycat.mycat2.beans.conf.DNBean;
-import io.mycat.mycat2.cmds.AbstractMultiDNExeCmd;
-import io.mycat.mycat2.cmds.DirectPassthrouhCmd;
-import io.mycat.mycat2.console.SessionKeyEnum;
-import io.mycat.mycat2.hbt.TableMeta;
-import io.mycat.mycat2.route.RouteResultset;
-import io.mycat.mycat2.route.RouteResultsetNode;
-import io.mycat.mycat2.tasks.DataNodeManager;
-import io.mycat.mycat2.tasks.HeapDataNodeMergeManager;
-import io.mycat.mycat2.tasks.SQLQueryStream;
-import io.mycat.mysql.packet.ErrorPacket;
-import io.mycat.proxy.ProxyBuffer;
-import io.mycat.proxy.ProxyRuntime;
-import io.mycat.util.ErrorCode;
+import java.io.IOException;
+import java.nio.channels.SelectionKey;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.nio.channels.SelectionKey;
+import io.mycat.mycat2.MySQLSession;
+import io.mycat.mycat2.MycatSession;
+import io.mycat.mycat2.cmds.AbstractMultiDNExeCmd;
+import io.mycat.mycat2.cmds.DirectPassthrouhCmd;
+import io.mycat.mycat2.route.RouteResultsetNode;
+import io.mycat.mycat2.tasks.BackendIOTaskWithGenericResponse;
+import io.mycat.mycat2.tasks.DataNodeManager;
+import io.mycat.mycat2.tasks.multinode.PickOnlyOneInMultiNodeWithGenericResponse;
+import io.mycat.mysql.packet.ErrorPacket;
+import io.mycat.proxy.ProxyBuffer;
+import io.mycat.util.ErrorCode;
 
 /**
  * <b><code>DbInMultiServerCmd</code></b>
@@ -41,120 +37,87 @@ public class DbInMultiServerCmd extends AbstractMultiDNExeCmd {
 
     private static final Logger logger = LoggerFactory.getLogger(DbInMultiServerCmd.class);
 
-    private static void broadcast(MycatSession mycatSession, RouteResultsetNode[] nodes) throws IOException {
+    private static void broadcast(MycatSession mycatSession, RouteResultsetNode[] nodes)
+            throws IOException {
         int size = nodes.length;
         for (int i = 0; i < size; i++) {
             RouteResultsetNode node = nodes[i];
             DataNodeManager manager = mycatSession.merge;
-            mycatSession.getBackendByDataNodeName(node.getName(), (mysqlsession, sender, success, result) -> {
-                try {
-                    if (success) {
-                        SQLQueryStream stream = new SQLQueryStream(node.getName(), mysqlsession, manager);
-                        manager.addSQLQueryStream(stream);
-                        stream.fetchSQL(node.getStatement());
-                    } else {
-                        //这个关闭方法会把所有backend都解除绑定并关闭
-                        manager.closeMutilBackendAndResponseError(success,
-                                ((ErrorPacket) result));
-                    }
-                } catch (Exception e) {
-                    String errmsg = "db in multi server cmd Error. " + e.getMessage();
-                    manager.closeMutilBackendAndResponseError(false, ErrorCode.ERR_MULTI_NODE_FAILED, errmsg);
-                }
-            });
+            mycatSession.getBackendByDataNodeName(node.getName(),
+                    (mysqlsession, sender, success, result) -> {
+                        try {
+                            if (success) {
+                                BackendIOTaskWithGenericResponse multiNodeBackendTask =
+                                        new PickOnlyOneInMultiNodeWithGenericResponse(mysqlsession,
+                                                mycatSession.getCurRouteResultset());
+                                multiNodeBackendTask.excecuteSQL(node.getStatement());
+                            } else {
+                                // 这个关闭方法会把所有backend都解除绑定并关闭
+                                manager.closeMutilBackendAndResponseError(success,
+                                        ((ErrorPacket) result));
+                            }
+                        } catch (Exception e) {
+                            String errmsg = "db in multi server cmd Error. " + e.getMessage();
+                            manager.closeMutilBackendAndResponseError(false,
+                                    ErrorCode.ERR_MULTI_NODE_FAILED, errmsg);
+                        }
+                    });
         }
-
     }
 
     @Override
     public boolean procssSQL(MycatSession mycatSession) throws IOException {
-        if (mycatSession.getCurRouteResultset() != null) {
-            RouteResultsetNode[] nodes = mycatSession.getCurRouteResultset().getNodes();
-            if (nodes.length == 1) {
-                transparent(mycatSession, nodes[0].getName());
-                return false;
-            }
-        } else {
-            DNBean dnBean = ProxyRuntime.INSTANCE.getConfig().getDNBean("dn1");
-            DNBean dnBean2 = ProxyRuntime.INSTANCE.getConfig().getDNBean("dn2");
-            String sql = mycatSession.sqlContext.getRealSQL(0);
-            RouteResultset curRouteResultset = new RouteResultset(sql, (byte) 0);
-            curRouteResultset.setNodes(
-                    new RouteResultsetNode[]{
-                            new RouteResultsetNode(dnBean.getName(), (byte) 1, sql),
-                            new RouteResultsetNode(dnBean2.getName(), (byte) 1, sql)});
-            mycatSession.setCurRouteResultset(curRouteResultset);
-            mycatSession.merge = new HeapDataNodeMergeManager(mycatSession.getCurRouteResultset(), mycatSession);
-            RouteResultsetNode[] nodes = mycatSession.merge.getRouteResultset().getNodes();
-            if (nodes != null && nodes.length > 0) {
-                broadcast(mycatSession, nodes);
-                return false;
-            }
+        RouteResultsetNode[] nodes = mycatSession.getCurRouteResultset().getNodes();
+        if (nodes.length == 1) {
+            passthrough(mycatSession, nodes[0]);
+            return false;
+        } else if (nodes.length > 1) {
+            broadcast(mycatSession, nodes);
+            return false;
         }
-        return inner.procssSQL(mycatSession);
+        return true;
     }
 
-    public boolean transparent(MycatSession session, String dataNodeName) throws IOException {
+    public boolean passthrough(MycatSession session, RouteResultsetNode node)
+            throws IOException {
         /*
          * 获取后端连接可能涉及到异步处理,这里需要先取消前端读写事件
          */
         session.clearReadWriteOpts();
 
-        session.getBackendByDataNodeName(dataNodeName, (mysqlsession, sender, success, result) -> {
-
-            ProxyBuffer curBuffer = session.proxyBuffer;
-            // 切换 buffer 读写状态
-            curBuffer.flip();
-            if (success) {
-                // 没有读取,直接透传时,需要指定 透传的数据 截止位置
-                curBuffer.readIndex = curBuffer.writeIndex;
-                // 改变 owner，对端Session获取，并且感兴趣写事件
-                session.giveupOwner(SelectionKey.OP_WRITE);
-                try {
-                    mysqlsession.writeToChannel();
-                } catch (IOException e) {
-                    session.closeBackendAndResponseError(mysqlsession, success, ((ErrorPacket) result));
-                }
-            } else {
-                session.closeBackendAndResponseError(mysqlsession, success, ((ErrorPacket) result));
-            }
-        });
+        session.getBackendByDataNodeName(node.getName(),
+                (mysqlsession, sender, success, result) -> {
+                    ProxyBuffer curBuffer = session.proxyBuffer;
+                    // 切换 buffer 读写状态
+                    curBuffer.flip();
+                    if (success) {
+                        // 没有读取,直接透传时,需要指定 透传的数据 截止位置
+                        curBuffer.readIndex = curBuffer.writeIndex;
+                        // 改变 owner，对端Session获取，并且感兴趣写事件
+                        session.giveupOwner(SelectionKey.OP_WRITE);
+                        try {
+                            mysqlsession.writeToChannel();
+                        } catch (IOException e) {
+                            session.closeBackendAndResponseError(mysqlsession, success,
+                                    ((ErrorPacket) result));
+                        }
+                    } else {
+                        session.closeBackendAndResponseError(mysqlsession, success,
+                                ((ErrorPacket) result));
+                    }
+                });
         return false;
     }
 
 
     @Override
     public boolean onFrontWriteFinished(MycatSession session) throws IOException {
-        if (checkMutil(session)) {
-            //@todo 改为迭代器实现
-            TableMeta tableMeta = ((HeapDataNodeMergeManager) session.merge).getTableMeta();
-            if (session.getSessionAttrMap().containsKey(SessionKeyEnum.SESSION_KEY_MERGE_OVER_FLAG.getKey()) && !tableMeta.isWriteFinish()) {
-                ProxyBuffer buffer = session.proxyBuffer;
-                buffer.reset();
-                tableMeta.writeRowData(buffer);
-                buffer.flip();
-                buffer.readIndex = buffer.writeIndex;
-                session.takeOwner(SelectionKey.OP_WRITE);
-                session.writeToChannel();
-                return false;
-            } else {
-                session.merge.onfinished();
-                session.getSessionAttrMap().remove(SessionKeyEnum.SESSION_KEY_MERGE_OVER_FLAG.getKey());
-                session.proxyBuffer.flip();
-                session.takeOwner(SelectionKey.OP_READ);
-                return true;
-            }
-        } else {
-            session.setCurRouteResultset(null);
-            return inner.onFrontWriteFinished(session);
-        }
+        session.setCurRouteResultset(null);
+        return inner.onFrontWriteFinished(session);
     }
 
     @Override
     public void clearFrontResouces(MycatSession session, boolean sessionCLosed) {
-        if (checkMutil(session)) {
-            session.merge.clearResouces();
-        }
         session.setCurRouteResultset(null);
         inner.clearFrontResouces(session, sessionCLosed);
     }
@@ -167,7 +130,7 @@ public class DbInMultiServerCmd extends AbstractMultiDNExeCmd {
     @Override
     public boolean onBackendResponse(MySQLSession session) throws IOException {
         if (checkMutil(session)) {
-            throw new IOException("it is a bug , should call Stream");
+            throw new IOException("it is a bug , should use BackendIOTask mechanism");
         }
         return inner.onBackendResponse(session);
     }
@@ -176,7 +139,7 @@ public class DbInMultiServerCmd extends AbstractMultiDNExeCmd {
     @Override
     public boolean onBackendWriteFinished(MySQLSession session) throws IOException {
         if (checkMutil(session)) {
-            throw new IOException("it is a bug , should call Stream");
+            throw new IOException("it is a bug , should use BackendIOTask mechanism");
         }
         return inner.onBackendWriteFinished(session);
     }
@@ -185,7 +148,7 @@ public class DbInMultiServerCmd extends AbstractMultiDNExeCmd {
     @Override
     public boolean onBackendClosed(MySQLSession session, boolean normal) throws IOException {
         if (checkMutil(session)) {
-            throw new IOException("it is a bug , should call Stream");
+            throw new IOException("it is a bug , should use BackendIOTask mechanism");
         }
         return inner.onBackendResponse(session);
     }
@@ -193,7 +156,7 @@ public class DbInMultiServerCmd extends AbstractMultiDNExeCmd {
     @Override
     public void clearBackendResouces(MySQLSession session, boolean sessionCLosed) {
         if (checkMutil(session)) {
-            logger.error("it is a bug , should call Stream");
+            logger.error("it is a bug , should use BackendIOTask mechanism");
         }
         inner.clearBackendResouces(session, sessionCLosed);
     }
@@ -205,9 +168,9 @@ public class DbInMultiServerCmd extends AbstractMultiDNExeCmd {
 
     private boolean checkMutil(MycatSession mycatSession) {
         if (mycatSession != null) {
-            DataNodeManager manager = mycatSession.merge;
-            if (manager != null) {
-                return manager.isMultiBackendMoreOne();
+            RouteResultsetNode[] nodes = mycatSession.getCurRouteResultset().getNodes();
+            if (nodes != null && nodes.length > 1) {
+                return true;
             }
         }
         return false;

--- a/source/src/main/java/io/mycat/mycat2/cmds/strategy/AbstractCmdStrategy.java
+++ b/source/src/main/java/io/mycat/mycat2/cmds/strategy/AbstractCmdStrategy.java
@@ -1,22 +1,29 @@
 package io.mycat.mycat2.cmds.strategy;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.mycat.mycat2.MySQLCommand;
 import io.mycat.mycat2.MycatSession;
 import io.mycat.mycat2.cmds.CmdStrategy;
 import io.mycat.mycat2.cmds.DirectPassthrouhCmd;
 import io.mycat.mycat2.cmds.interceptor.SQLAnnotationChain;
 import io.mycat.mycat2.cmds.manager.MyCatCmdDispatcher;
-import io.mycat.mycat2.sqlannotations.*;
+import io.mycat.mycat2.sqlannotations.AnnotationDataNode;
+import io.mycat.mycat2.sqlannotations.AnnotationDataNodeMeta;
+import io.mycat.mycat2.sqlannotations.CacheResult;
+import io.mycat.mycat2.sqlannotations.CacheResultMeta;
+import io.mycat.mycat2.sqlannotations.CatletMeta;
+import io.mycat.mycat2.sqlannotations.CatletResult;
+import io.mycat.mycat2.sqlannotations.SQLAnnotation;
 import io.mycat.mycat2.sqlparser.BufferSQLContext;
 import io.mycat.mycat2.sqlparser.BufferSQLParser;
 import io.mycat.mysql.packet.MySQLPacket;
 import io.mycat.util.ErrorCode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 public abstract class AbstractCmdStrategy implements CmdStrategy {
 	
@@ -116,9 +123,9 @@ public abstract class AbstractCmdStrategy implements CmdStrategy {
 			command = DirectPassthrouhCmd.INSTANCE;
 		}
 
-//        if (!delegateRoute(session)) {
-//            return false;
-//        }
+        if (!delegateRoute(session)) {
+            return false;
+        }
 
 		/**
 		 * 设置原始处理命令
@@ -129,7 +136,7 @@ public abstract class AbstractCmdStrategy implements CmdStrategy {
 		 */
 		SQLAnnotationChain chain = new SQLAnnotationChain();
         session.curSQLCommand =
-                chain.setTarget(command).processRoute(session).processDynamicAnno(session)
+                chain.setTarget(command).processDynamicAnno(session)
                         .processStaticAnno(session, staticAnnontationMap).build();
 		return true;
 	}

--- a/source/src/main/java/io/mycat/mycat2/cmds/strategy/DBINMultiServerCmdStrategy.java
+++ b/source/src/main/java/io/mycat/mycat2/cmds/strategy/DBINMultiServerCmdStrategy.java
@@ -104,7 +104,7 @@ public class DBINMultiServerCmdStrategy extends AbstractCmdStrategy {
 
 
         if (routeResultset.getNodes() != null && routeResultset.getNodes().length > 1
-                && !routeResultset.isGlobalTable()) {
+                && (!routeResultset.isGlobalTable() || session.sqlContext.isSelect())) {
 
             session.setCurRouteResultset(null);
             try {

--- a/source/src/main/java/io/mycat/mycat2/cmds/strategy/DBINMultiServerCmdStrategy.java
+++ b/source/src/main/java/io/mycat/mycat2/cmds/strategy/DBINMultiServerCmdStrategy.java
@@ -1,15 +1,33 @@
 package io.mycat.mycat2.cmds.strategy;
 
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.mycat.mycat2.MycatSession;
-import io.mycat.mycat2.cmds.*;
+import io.mycat.mycat2.cmds.ComChangeUserCmd;
+import io.mycat.mycat2.cmds.ComFieldListCmd;
+import io.mycat.mycat2.cmds.ComInitDB;
+import io.mycat.mycat2.cmds.ComPingCmd;
+import io.mycat.mycat2.cmds.ComQuitCmd;
+import io.mycat.mycat2.cmds.ComStatisticsCmd;
+import io.mycat.mycat2.cmds.DirectPassthrouhCmd;
+import io.mycat.mycat2.cmds.NotSupportCmd;
+import io.mycat.mycat2.cmds.ShowDbCmd;
+import io.mycat.mycat2.cmds.ShowTbCmd;
 import io.mycat.mycat2.cmds.multinode.DbInMultiServerCmd;
-import io.mycat.mycat2.cmds.sqlCmds.*;
+import io.mycat.mycat2.cmds.sqlCmds.SqlComBeginCmd;
+import io.mycat.mycat2.cmds.sqlCmds.SqlComCommitCmd;
+import io.mycat.mycat2.cmds.sqlCmds.SqlComRollBackCmd;
+import io.mycat.mycat2.cmds.sqlCmds.SqlComShutdownCmd;
+import io.mycat.mycat2.cmds.sqlCmds.SqlComStartCmd;
+import io.mycat.mycat2.route.RouteResultset;
 import io.mycat.mycat2.route.RouteStrategy;
 import io.mycat.mycat2.route.impl.DBInMultiServerRouteStrategy;
 import io.mycat.mycat2.sqlparser.BufferSQLContext;
 import io.mycat.mysql.packet.MySQLPacket;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.mycat.util.ErrorCode;
 
 public class DBINMultiServerCmdStrategy extends AbstractCmdStrategy {
 
@@ -17,7 +35,8 @@ public class DBINMultiServerCmdStrategy extends AbstractCmdStrategy {
 
     public static final DBINMultiServerCmdStrategy INSTANCE = new DBINMultiServerCmdStrategy();
 
-    private RouteStrategy routeStrategy = new DBInMultiServerRouteStrategy();
+    private RouteStrategy dbInMultiServerRouteStrategy = new DBInMultiServerRouteStrategy();
+
 
     @Override
     protected void initMyCmdHandler() {
@@ -56,9 +75,10 @@ public class DBINMultiServerCmdStrategy extends AbstractCmdStrategy {
 
     @Override
     protected void initMySqlCmdHandler() {
-        MYSQLCOMMANDMAP.put(BufferSQLContext.INSERT_SQL, DirectPassthrouhCmd.INSTANCE);
-        MYSQLCOMMANDMAP.put(BufferSQLContext.UPDATE_SQL, DirectPassthrouhCmd.INSTANCE);
-        MYSQLCOMMANDMAP.put(BufferSQLContext.DROP_SQL, DirectPassthrouhCmd.INSTANCE);
+        MYSQLCOMMANDMAP.put(BufferSQLContext.INSERT_SQL, DbInMultiServerCmd.INSTANCE);
+        MYSQLCOMMANDMAP.put(BufferSQLContext.UPDATE_SQL, DbInMultiServerCmd.INSTANCE);
+        MYSQLCOMMANDMAP.put(BufferSQLContext.DELETE_SQL, DbInMultiServerCmd.INSTANCE);
+        MYSQLCOMMANDMAP.put(BufferSQLContext.DROP_SQL, DbInMultiServerCmd.INSTANCE);
         MYSQLCOMMANDMAP.put(BufferSQLContext.COMMIT_SQL, SqlComCommitCmd.INSTANCE);
         MYSQLCOMMANDMAP.put(BufferSQLContext.ROLLBACK_SQL, SqlComRollBackCmd.INSTANCE);
         MYSQLCOMMANDMAP.put(BufferSQLContext.SELECT_SQL, DbInMultiServerCmd.INSTANCE);
@@ -75,29 +95,32 @@ public class DBINMultiServerCmdStrategy extends AbstractCmdStrategy {
 
     @Override
     protected boolean delegateRoute(MycatSession session) {
-//
-//        byte sqltype = session.sqlContext.getSQLType() != 0 ? session.sqlContext.getSQLType()
-//                : session.sqlContext.getCurSQLType();
-//        RouteResultset routeResultset = routeStrategy.route(session.schema, sqltype,
-//                session.sqlContext.getRealSQL(0), null, session);
-//
-//        if (routeResultset.getNodes() != null && routeResultset.getNodes().length > 1 && !routeResultset.isGlobalTable()) {
-//
-//            session.curRouteResultset = null;
-//            try {
-//                logger.error(
-//                        "Multi node error! Not allowed to execute SQL statement across data nodes in DB_IN_MULTI_SERVER schemaType.\n"
-//                                + "Original SQL:[{}]",
-//                        session.sqlContext.getRealSQL(0));
-//                session.sendErrorMsg(ErrorCode.ERR_MULTI_NODE_FAILED,
-//                        "Not allowed to execute SQL statement across data nodes in DB_IN_MULTI_SERVER schemaType.");
-//            } catch (IOException e) {
-//                session.close(false, e.getMessage());
-//            }
-//            return false;
-//        } else {
-//            session.curRouteResultset = routeResultset;
-//        }
+
+        byte sqltype = session.sqlContext.getSQLType() != 0 ? session.sqlContext.getSQLType()
+                : session.sqlContext.getCurSQLType();
+
+        RouteResultset routeResultset = dbInMultiServerRouteStrategy.route(session.schema, sqltype,
+                session.sqlContext.getRealSQL(0), null, session);
+
+
+        if (routeResultset.getNodes() != null && routeResultset.getNodes().length > 1
+                && !routeResultset.isGlobalTable()) {
+
+            session.setCurRouteResultset(null);
+            try {
+                logger.error(
+                        "Multi node error! Not allowed to execute SQL statement across data nodes in DB_IN_MULTI_SERVER schemaType.\n"
+                                + "Original SQL:[{}]",
+                        session.sqlContext.getRealSQL(0));
+                session.sendErrorMsg(ErrorCode.ERR_MULTI_NODE_FAILED,
+                        "Not allowed to execute SQL statement across data nodes in DB_IN_MULTI_SERVER schemaType.");
+            } catch (IOException e) {
+                session.close(false, e.getMessage());
+            }
+            return false;
+        } else {
+            session.setCurRouteResultset(routeResultset);
+        }
         return true;
     }
 }

--- a/source/src/main/java/io/mycat/mycat2/route/RouteResultset.java
+++ b/source/src/main/java/io/mycat/mycat2/route/RouteResultset.java
@@ -23,15 +23,15 @@
  */
 package io.mycat.mycat2.route;
 
-import io.mycat.mycat2.MySQLSession;
-import io.mycat.util.FormatUtil;
-
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import io.mycat.mycat2.MySQLSession;
+import io.mycat.util.FormatUtil;
 
 /**
  * @author mycat

--- a/source/src/main/java/io/mycat/mycat2/route/impl/DBInMultiServerRouteStrategy.java
+++ b/source/src/main/java/io/mycat/mycat2/route/impl/DBInMultiServerRouteStrategy.java
@@ -18,7 +18,7 @@ import io.mycat.proxy.ProxyRuntime;
 /**
  * <b><code>DBInMultiServerRouteStrategy</code></b>
  * <p>
- * DBInMultiServer模式下的路由策略，该模式下不允许跨库.
+ * DBInMultiServer模式下的路由策略，该模式下除全局表外不允许跨库.
  * </p>
  * <b>Creation Time:</b> 2017-12-24
  * 
@@ -52,7 +52,7 @@ public class DBInMultiServerRouteStrategy implements RouteStrategy {
                 dataNodes.add(schema.getDefaultDataNode());
             }
         }
-        // 就全局表而言，只有查询操作不需要跨节点，其他都要
+        // 就全局表而言，只有查询操作不需要跨节点，其他操作都要
         if (sqlType != BufferSQLContext.SELECT_SQL
                 && sqlType != BufferSQLContext.SELECT_FOR_UPDATE_SQL
                 && sqlType != BufferSQLContext.SELECT_INTO_SQL) {

--- a/source/src/main/java/io/mycat/mycat2/route/impl/DBInMultiServerRouteStrategy.java
+++ b/source/src/main/java/io/mycat/mycat2/route/impl/DBInMultiServerRouteStrategy.java
@@ -59,7 +59,7 @@ public class DBInMultiServerRouteStrategy implements RouteStrategy {
             dataNodes.addAll(globalDataNodes);
         } else {
             if (!globalDataNodes.isEmpty()) {
-                dataNodes.add(globalDataNodes.stream().findFirst().get());
+                dataNodes.retainAll(globalDataNodes);
             }
         }
         RouteResultset rrs = new RouteResultset(origSQL, sqlType);

--- a/source/src/main/java/io/mycat/mycat2/sqlparser/BufferSQLContext.java
+++ b/source/src/main/java/io/mycat/mycat2/sqlparser/BufferSQLContext.java
@@ -305,6 +305,11 @@ public class BufferSQLContext {
                 || sqlType == TRUNCATE_SQL;
     }
 
+    public boolean isSelect() {
+        return this.getSQLType() == SELECT_SQL || this.getSQLType() == SELECT_INTO_SQL
+                || this.getSQLType() == SELECT_FOR_UPDATE_SQL;
+    }
+
     public void setSQLIdx(int sqlIdx) {
         curSQLIdx = sqlIdx;
     }

--- a/source/src/main/java/io/mycat/mycat2/sqlparser/BufferSQLContext.java
+++ b/source/src/main/java/io/mycat/mycat2/sqlparser/BufferSQLContext.java
@@ -1,10 +1,10 @@
 package io.mycat.mycat2.sqlparser;
 
+import java.util.Arrays;
+
 import io.mycat.mycat2.sqlparser.SQLParseUtils.HashArray;
 import io.mycat.mycat2.sqlparser.byteArrayInterface.ByteArrayInterface;
 import io.mycat.mycat2.sqlparser.byteArrayInterface.TokenizerUtil;
-
-import java.util.Arrays;
 
 /**
  * <pre>
@@ -22,6 +22,8 @@ public class BufferSQLContext {
     public static final byte DROP_SQL = 3;    //TODO 进一步细化，区分
     public static final byte TRUNCATE_SQL = 4;
     //    public static final byte COMMENT_SQL = 5;
+
+    // DAL (Database Administration Statements)
     public static final byte RENAME_SQL = 6;
     public static final byte USE_SQL = 7;
     public static final byte SHOW_SQL = 8;    //TODO 进一步细化。区分

--- a/source/src/main/java/io/mycat/mycat2/tasks/BackendIOTaskWithGenericResponse.java
+++ b/source/src/main/java/io/mycat/mycat2/tasks/BackendIOTaskWithGenericResponse.java
@@ -1,0 +1,76 @@
+package io.mycat.mycat2.tasks;
+
+import java.io.IOException;
+
+import io.mycat.mycat2.AbstractMySQLSession;
+import io.mycat.mycat2.MySQLSession;
+import io.mycat.mycat2.console.SessionKeyEnum;
+import io.mycat.mysql.packet.MySQLPacket;
+import io.mycat.mysql.packet.QueryPacket;
+import io.mycat.proxy.ProxyBuffer;
+
+/**
+ * 
+ * <b><code>MultiNodeBackendTaskWithGenericResponse</code></b>
+ * <p>
+ * Generic Response Packet（如OK_Packet,ERR_Packet）的Task处理类.
+ * </p>
+ * <b>Creation Time:</b> 2018-04-28
+ * 
+ * @author <a href="mailto:flysqrlboy@gmail.com">zhangsiwei</a>
+ * @since 2.0
+ */
+public abstract class BackendIOTaskWithGenericResponse
+        extends AbstractBackendIOTask<MySQLSession> {
+
+    public void excecuteSQL(String sql) throws IOException {
+        QueryPacket queryPacket = new QueryPacket();
+        queryPacket.packetId = 0;
+        queryPacket.sql = sql;
+        /*设置为忙*/
+        session.getSessionAttrMap().put(SessionKeyEnum.SESSION_KEY_CONN_IDLE_FLAG.getKey(), false);
+        ProxyBuffer proxyBuf = session.proxyBuffer;
+        proxyBuf.reset();
+        queryPacket.write(proxyBuf);
+        session.setCurNIOHandler(this);
+        proxyBuf.flip();
+        proxyBuf.readIndex = proxyBuf.writeIndex;
+        this.session.writeToChannel();
+    }
+
+
+    @Override
+    public void onSocketRead(MySQLSession session) throws IOException {
+
+        if (!session.readFromChannel()) {
+            return;
+        }
+        AbstractMySQLSession.CurrPacketType currPacketType =
+                session.resolveMySQLPackage(session.proxyBuffer, session.curMSQLPackgInf, false);
+
+        session.proxyBuffer.flip();
+        if (currPacketType == AbstractMySQLSession.CurrPacketType.Full) {
+
+            try {
+                if (session.curMSQLPackgInf.pkgType == MySQLPacket.OK_PACKET) {
+                    onOkResponse(session);
+                } else if (session.curMSQLPackgInf.pkgType == MySQLPacket.ERROR_PACKET) {
+                    onErrResponse(session);
+                }
+            } catch (Exception ex) {
+                onFinished(false, session);
+            }
+            onFinished(true, session);
+
+        } else {
+            return;
+        }
+    }
+
+    public abstract void onOkResponse(MySQLSession session) throws IOException;
+
+    public abstract void onErrResponse(MySQLSession session) throws IOException;
+
+    public abstract void onFinished(boolean success, MySQLSession session) throws IOException;
+
+}

--- a/source/src/main/java/io/mycat/mycat2/tasks/multinode/PickOnlyOneInMultiNodeWithGenericResponse.java
+++ b/source/src/main/java/io/mycat/mycat2/tasks/multinode/PickOnlyOneInMultiNodeWithGenericResponse.java
@@ -1,0 +1,77 @@
+package io.mycat.mycat2.tasks.multinode;
+
+import java.io.IOException;
+
+import org.apache.log4j.Logger;
+
+import io.mycat.mycat2.MySQLSession;
+import io.mycat.mycat2.console.SessionKeyEnum;
+import io.mycat.mycat2.net.DefaultMycatSessionHandler;
+import io.mycat.mycat2.route.RouteResultset;
+import io.mycat.mycat2.tasks.BackendIOTaskWithGenericResponse;
+import io.mycat.mysql.packet.OKPacket;
+import io.mycat.proxy.ProxyBuffer;
+
+/**
+ * 
+ * <b><code>PickOnlyOneInMultiNodeWithGenericResponse</code></b>
+ * <p>
+ * 多节点下只选择其中一个节点的返回结果。 例如针对全局表的DML语句，在成功的情况下，只需返回其中一个OK_Packet。
+ * </p>
+ * <b>Creation Time:</b> 2018-04-28
+ * 
+ * @author <a href="mailto:flysqrlboy@gmail.com">zhangsiwei</a>
+ * @since 2.0
+ */
+public class PickOnlyOneInMultiNodeWithGenericResponse extends BackendIOTaskWithGenericResponse {
+
+    private static Logger LOGGER = Logger.getLogger(PickOnlyOneInMultiNodeWithGenericResponse.class);
+    private RouteResultset routeResultset;
+
+    public PickOnlyOneInMultiNodeWithGenericResponse(MySQLSession session, RouteResultset rrs) {
+
+        /*
+         * useNewBuffer为true，表示mysqlsession使用自己的proxyBuffer，
+         * 而没有与mycatsession共用proxyBuffer
+         */
+        this.setSession(session, true);
+        this.routeResultset = rrs;
+    }
+
+    @Override
+    public void onOkResponse(MySQLSession session) throws IOException {
+
+        routeResultset.countDown(session, () -> {
+            try {
+                OKPacket okpkg = new OKPacket();
+                okpkg.read(session.proxyBuffer);
+
+                ProxyBuffer proxyBuffer = session.getMycatSession().proxyBuffer;
+                proxyBuffer.reset();
+                okpkg.write(proxyBuffer);
+                proxyBuffer.flip();
+                proxyBuffer.readIndex = proxyBuffer.writeIndex;
+                session.getMycatSession().takeBufferOwnerOnly();
+                session.getMycatSession().writeToChannel();
+            } catch (IOException ex) {
+                LOGGER.error(ex);
+            }
+
+        });
+    }
+
+    @Override
+    public void onErrResponse(MySQLSession session) {
+        // TODO 待实现，收到Error packet响应后应该执行回滚（分布式事务）
+
+    }
+
+    @Override
+    public void onFinished(boolean success, MySQLSession session) throws IOException {
+        // 恢复默认的Handler
+        session.setCurNIOHandler(DefaultMycatSessionHandler.INSTANCE);
+        // 把mysqlsession的proxybuffer切换回原来的共享buffer，即与mycatSession共享的buffer
+        revertPreBuffer();
+        session.getSessionAttrMap().remove(SessionKeyEnum.SESSION_KEY_CONN_IDLE_FLAG.getKey());;
+    }
+}

--- a/source/src/main/java/io/mycat/mysql/packet/OKPacket.java
+++ b/source/src/main/java/io/mycat/mysql/packet/OKPacket.java
@@ -44,6 +44,7 @@ import io.mycat.util.BufferUtil;
  * @author mycat
  */
 public class OKPacket extends MySQLPacket {
+
 	public byte pkgType = MySQLPacket.OK_PACKET;
 
 	public static final byte FIELD_COUNT = 0x00;
@@ -79,9 +80,7 @@ public class OKPacket extends MySQLPacket {
 		serverStatus = (int) buffer.readFixInt(2);
 		warningCount = (int) buffer.readFixInt(2);
 		if (index + packetLength + MySQLPacket.packetHeaderSize - buffer.readIndex > 0) {
-			int msgLength = index + packetLength + MySQLPacket.packetHeaderSize - buffer.readIndex;
-			this.message = buffer.getBytes(buffer.writeIndex, msgLength);
-			buffer.readIndex += msgLength;
+            this.message = buffer.readLenencString().getBytes();
 		}
 	}
 


### PR DESCRIPTION
1. 对dbinMultiServer模式进行重构，主要是引入AbstractBackendIOTask来处理后端请求和响应。
2. 重新支持dbinMultiServer模式的路由。