### PR TITLE
修复Bug：直接通过MycatSession写入OK或者ERROR报文的情况下，透传状态机无法正确判断响应结束，因此前端不能切换到读状态以…

### DIFF
--- a/source/src/main/java/io/mycat/mycat2/MycatSession.java
+++ b/source/src/main/java/io/mycat/mycat2/MycatSession.java
@@ -27,6 +27,7 @@ import io.mycat.mysql.AutoCommit;
 import io.mycat.mysql.Capabilities;
 import io.mycat.mysql.packet.ErrorPacket;
 import io.mycat.mysql.packet.HandshakePacket;
+import io.mycat.mysql.packet.MySQLPacket;
 import io.mycat.proxy.MycatReactorThread;
 import io.mycat.proxy.ProxyRuntime;
 import io.mycat.proxy.buffer.BufferPool;
@@ -357,6 +358,14 @@ public class MycatSession extends AbstractMySQLSession {
 		}
 		return backendName;
 	}
+	public void responseOKOrError(byte[] pkg) throws IOException {
+		this.responseStateMachine.in((byte) 25);
+		super.responseOKOrError(pkg);
+	}
+	public void responseOKOrError(MySQLPacket pkg) {
+		this.responseStateMachine.in((byte) 25);
+		super.responseOKOrError(pkg);
+	}
 
 	/**
 	 * 将后端连接放入到后端连接缓存中
@@ -449,7 +458,6 @@ public class MycatSession extends AbstractMySQLSession {
 			reactorThread.tryGetMySQLAndExecute(this, runOnSlave, targetMetaBean, callback);
 		}
 	}
-
 	/**
 	 * 获取指定的复制组
 	 *

--- a/source/src/main/java/io/mycat/mycat2/net/MainMycatNIOHandler.java
+++ b/source/src/main/java/io/mycat/mycat2/net/MainMycatNIOHandler.java
@@ -110,7 +110,8 @@ public class MainMycatNIOHandler implements NIOHandler<MycatSession> {
 
     @Override
     public void onWriteFinished(MycatSession session) throws IOException {
-        // 交给SQLComand去处理
+    	logger.debug("write finished  {}",this);
+    	// 交给SQLComand去处理
         if (session.curSQLCommand.onFrontWriteFinished(session)) {
             session.curSQLCommand.clearFrontResouces(session, false);
         }

--- a/source/src/main/java/io/mycat/mysql/packet/ErrorPacket.java
+++ b/source/src/main/java/io/mycat/mysql/packet/ErrorPacket.java
@@ -64,7 +64,8 @@ public class ErrorPacket extends MySQLPacket {
         	byteBuffer.skip(1);
             sqlState = byteBuffer.readBytes(5);
         }
-        message = byteBuffer.readNULString();
+       
+        message = byteBuffer.readEOFString();
     }
 
     public void write(ProxyBuffer buffer){
@@ -75,7 +76,7 @@ public class ErrorPacket extends MySQLPacket {
         buffer.writeByte(mark);
         buffer.writeBytes(sqlState);
         if (message != null) {
-            buffer.writeNULString(message);
+            buffer.writeEOFString(message);
 
         }
     }
@@ -84,7 +85,7 @@ public class ErrorPacket extends MySQLPacket {
     public int calcPacketSize() {
         int size = 9;// 1 + 2 + 1 + 5
         if (message != null) {
-            size += message.length()+1;
+            size += message.length();
         }
         return size;
     }

--- a/source/src/main/java/io/mycat/proxy/AbstractSession.java
+++ b/source/src/main/java/io/mycat/proxy/AbstractSession.java
@@ -173,7 +173,7 @@ public abstract class AbstractSession implements Session {
 		buffer.limit(proxyBuffer.readIndex);
 		buffer.position(proxyBuffer.readMark);
 		final String hexs = StringUtil.dumpAsHex(buffer, buffer.position(), buffer.remaining());
-		logger.debug( hexs);
+		logger.debug("{} write to session {} ",this, hexs);
 		int writed = channel.write(buffer);
 		
 		proxyBuffer.readMark += writed; // 记录本次磁轭如到 Channel 中的数据
@@ -249,6 +249,7 @@ public abstract class AbstractSession implements Session {
 		// 事件转换时,只注册一个事件,存在可写事件没有取消注册的情况。这里把判断取消
 		// if ((intesOpts & SelectionKey.OP_READ) != SelectionKey.OP_READ) {
 		channelKey.interestOps(SelectionKey.OP_READ);
+		logger.debug("change to read opts {}",this);
 		// }
 	}
 
@@ -262,6 +263,7 @@ public abstract class AbstractSession implements Session {
 		// 事件转换时,只注册一个事件,存在可读事件没有取消注册的情况。这里把判断取消
 		// if ((intesOpts & SelectionKey.OP_WRITE) != SelectionKey.OP_WRITE) {
 		channelKey.interestOps(SelectionKey.OP_WRITE);
+		logger.debug("change to write opts {}",this);
 		// }
 	}
 

--- a/source/src/main/java/io/mycat/proxy/ProxyBuffer.java
+++ b/source/src/main/java/io/mycat/proxy/ProxyBuffer.java
@@ -303,6 +303,19 @@ public class ProxyBuffer {
         readIndex += rv.getBytes().length + 1;
         return rv;
     }
+    
+    public String getEOFString(int index) {
+        int strLength =writeIndex-index+1;
+        byte[] bytes = getBytes(index, strLength);
+        return new String(bytes);
+    }
+
+    public String readEOFString() {
+        String rv = getEOFString(readIndex);
+        readIndex += rv.getBytes().length;
+        return rv;
+    }
+
 
     public ProxyBuffer putFixInt(int index, int length, long val) {
         int index0 = index;
@@ -449,6 +462,12 @@ public class ProxyBuffer {
         return this;
     }
 
+    public ProxyBuffer writeEOFString(String val) {
+        byte[] bytes = val.getBytes();
+        putFixString(writeIndex, bytes);
+        writeIndex += bytes.length;
+        return this;
+    }
     public byte[] readBytes(int length) {
         byte[] bytes = this.getBytes(readIndex, length);
         readIndex += length;


### PR DESCRIPTION
…处理下一个命令。同时发现OK报文与ERR报文的错误。