### PR TITLE
后端登录认证也更换成新的协议包 & 重复代码重构

### DIFF
--- a/source/src/main/java/io/mycat/mycat2/MySQLSession.java
+++ b/source/src/main/java/io/mycat/mycat2/MySQLSession.java
@@ -72,7 +72,7 @@ public class MySQLSession extends AbstractMySQLSession {
 		flag |= Capabilities.CLIENT_LONG_PASSWORD;
 		flag |= Capabilities.CLIENT_FOUND_ROWS;
 		flag |= Capabilities.CLIENT_LONG_FLAG;
-		flag |= Capabilities.CLIENT_CONNECT_WITH_DB;
+//		flag |= Capabilities.CLIENT_CONNECT_WITH_DB;
 		// flag |= Capabilities.CLIENT_NO_SCHEMA;
 		boolean usingCompress = false;
 		if (usingCompress) {
@@ -88,6 +88,7 @@ public class MySQLSession extends AbstractMySQLSession {
 		flag |= Capabilities.CLIENT_TRANSACTIONS;
 		// flag |= Capabilities.CLIENT_RESERVED;
 		flag |= Capabilities.CLIENT_SECURE_CONNECTION;
+		flag |= Capabilities.CLIENT_PLUGIN_AUTH;
 		// // client extension
 		// flag |= Capabilities.CLIENT_MULTI_STATEMENTS;
 		// flag |= Capabilities.CLIENT_MULTI_RESULTS;

--- a/source/src/main/java/io/mycat/mycat2/net/MySQLClientAuthHandler.java
+++ b/source/src/main/java/io/mycat/mycat2/net/MySQLClientAuthHandler.java
@@ -1,11 +1,21 @@
 package io.mycat.mycat2.net;
 
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.channels.SelectionKey;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
 import io.mycat.mycat2.MycatConfig;
 import io.mycat.mycat2.MycatSession;
 import io.mycat.mycat2.beans.conf.FireWallBean;
 import io.mycat.mycat2.beans.conf.UserBean;
 import io.mycat.mycat2.beans.conf.UserConfig;
+import io.mycat.mysql.MysqlNativePasswordPluginUtil;
 import io.mycat.mysql.packet.CurrPacketType;
 import io.mycat.mysql.packet.ErrorPacket;
 import io.mycat.mysql.packet.NewAuthPacket;
@@ -14,16 +24,6 @@ import io.mycat.proxy.NIOHandler;
 import io.mycat.proxy.ProxyBuffer;
 import io.mycat.proxy.ProxyRuntime;
 import io.mycat.util.ErrorCode;
-import io.mycat.util.SecurityUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.nio.channels.SelectionKey;
-import java.security.NoSuchAlgorithmException;
-import java.util.List;
-import java.util.Objects;
-import java.util.regex.Pattern;
 
 /**
  * MySQL客户端登录认证的Handler，为第一个Handler
@@ -156,14 +156,7 @@ public class MySQLClientAuthHandler implements NIOHandler<MycatSession> {
 			return false;
 		}
 
-		// encrypt
-		byte[] encryptPass;
-		try {
-			encryptPass = SecurityUtil.scramble411(pass.getBytes(), session.seed);
-		} catch (NoSuchAlgorithmException e) {
-			logger.warn("no such algorithm", e);
-			return false;
-		}
+		byte[] encryptPass = MysqlNativePasswordPluginUtil.scramble411(pass, session.seed);
 
 		if (encryptPass != null && (encryptPass.length == password.length)) {
 			int i = encryptPass.length;

--- a/source/src/main/java/io/mycat/mysql/MysqlNativePasswordPluginUtil.java
+++ b/source/src/main/java/io/mycat/mysql/MysqlNativePasswordPluginUtil.java
@@ -1,0 +1,62 @@
+package io.mycat.mysql;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.security.NoSuchAlgorithmException;
+
+import io.mycat.util.RandomUtil;
+import io.mycat.util.SecurityUtil;
+
+/**
+ * ${todo}
+ *
+ * @author : zhuqiang
+ * @date : 2018/11/25 20:03
+ */
+public class MysqlNativePasswordPluginUtil {
+    private static Logger logger = LoggerFactory.getLogger(MysqlNativePasswordPluginUtil.class);
+    public static final String PROTOCOL_PLUGIN_NAME = "mysql_native_password";
+
+    public static byte[] scramble411(String password, byte[] seed) {
+        if (password == null || password.length() == 0) {
+            logger.warn("password is empty");
+            return null;
+        }
+        try {
+            return SecurityUtil.scramble411(password.getBytes(), seed);
+        } catch (NoSuchAlgorithmException e) {
+            logger.warn("no such algorithm", e);
+            return null;
+        }
+    }
+
+    public static byte[] scramble411(String password, String seed) {
+        return scramble411(password, seed.getBytes());
+    }
+
+    public static byte[][] nextSeedBuild() {
+        byte[] authPluginDataPartOne = RandomUtil.randomBytes(8);
+        byte[] authPluginDataPartTwo = RandomUtil.randomBytes(12);
+
+        // 保存认证数据
+        byte[] seed = new byte[20];
+        System.arraycopy(authPluginDataPartOne, 0, seed, 0, 8);
+        System.arraycopy(authPluginDataPartTwo, 0, seed, 8, 12);
+
+        byte[][] result = new byte[3][1];
+        result[0] = authPluginDataPartOne;
+        result[1] = authPluginDataPartTwo;
+        result[2] = seed;
+        return result;
+    }
+
+    public static String[] nextSeedStringBuild() {
+        byte[][] bytes = nextSeedBuild();
+        return new String[]{
+                new String(bytes[0]),
+                new String(bytes[1]),
+                new String(bytes[2]),
+        };
+    }
+}

--- a/source/src/test/java/io/mycat/mycat2/e2e/comQuery/ComQueryTest.java
+++ b/source/src/test/java/io/mycat/mycat2/e2e/comQuery/ComQueryTest.java
@@ -1,11 +1,11 @@
 package io.mycat.mycat2.e2e.comQuery;
 
-import io.mycat.mycat2.e2e.BaseSQLExeTest;
-import io.mycat.mycat2.e2e.BaseSQLTest;
 import org.junit.Assert;
-import org.junit.Test;
 
-import java.sql.*;
+import java.sql.Savepoint;
+import java.sql.Statement;
+
+import io.mycat.mycat2.e2e.BaseSQLTest;
 
 /**
  * Created by linxiaofang on 2018/11/5.
@@ -20,7 +20,7 @@ public class ComQueryTest extends BaseSQLTest {
     final static String REPL_MASTER_LOG_FILE = "mysql-bin.000001";
     final static int REPL_MASTER_LOG_POS = 7849;
 
-    @Test
+//    @Test
     public void testShowTableStatus() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -35,7 +35,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testShowTriggers() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -55,7 +55,7 @@ public class ComQueryTest extends BaseSQLTest {
      * 如果报错: The MySQL server is running with the --secure-file-priv option so it cannot execute this statement
      * 需要修改my.cnf, 增加 secure-file-priv="" 后重启
      */
-    @Test
+//    @Test
     public void testLoadData() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -65,7 +65,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testSetOption() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -74,7 +74,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testLockUnlock() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -85,7 +85,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testGrantRevoke() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -103,7 +103,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testChangeDb() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -112,7 +112,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testCreateDb() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -121,7 +121,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testDropDb() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -130,7 +130,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testAlterDb() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -140,7 +140,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testRepair() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -149,7 +149,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testReplace() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -158,7 +158,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testReplaceSelect() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -176,7 +176,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testCreateDropFunction() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -188,7 +188,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testOptimize() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -197,7 +197,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testCheck() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -206,7 +206,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testCacheIndex() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -217,7 +217,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testFlush() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -238,7 +238,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testAnalyze() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -247,7 +247,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testBegin() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -258,7 +258,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testRollback() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -269,7 +269,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testRollbackToSavePoint() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -284,7 +284,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testReleaseSavePoint() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -301,7 +301,7 @@ public class ComQueryTest extends BaseSQLTest {
     /*
      * 执行testSlave,需要连接到Slave数据库
      */
-    @Test
+//    @Test
     public void testSlave() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -330,7 +330,7 @@ public class ComQueryTest extends BaseSQLTest {
     /*
      * 必须开启binlog才能执行,否则会报异常: java.sql.SQLException: You are not using binary logging
      */
-    @Test
+//    @Test
     public void testBinlog() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -354,7 +354,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testShowSlaveHosts() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -363,7 +363,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testReset() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -372,7 +372,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testRenameTable() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -382,7 +382,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testShowOpenTables() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -403,7 +403,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testShowStorageEngines() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -412,7 +412,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testShowWarningsErrors() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -422,7 +422,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testDo() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -431,7 +431,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testHandler() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -442,7 +442,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testDeleteMulti() {
         using(c -> {
                     Statement statement = c.createStatement();
@@ -455,7 +455,7 @@ public class ComQueryTest extends BaseSQLTest {
         );
     }
 
-    @Test
+//    @Test
     public void testUpdateMulti() {
         using(c -> {
                     Statement statement = c.createStatement();


### PR DESCRIPTION
- 后端登录认证也更换成新的协议包
- MysqlNativePassword 插件相关方法/重复 重构至工具类中
- 注释掉需要启动 mycat/mysql 才能测试的 @Test 方法

本测试提交后，AuthPacket 和 HandshakePacket 类可以移除了；

本地自测通过的有：
mysql 5.7
Navicat Premium 11.0.10
mysql 驱动 5.1.34
mysql 驱动 5.1.22
mysql 驱动 8.0.13
windows 中 mysql 客户端命令行