### PR TITLE
关于proxy模块的MySQLSessionManager类中设置游标声明ID和分母为零的处理

### DIFF
--- a/example/src/main/java/io/mycat/example/readWriteSeparation/ReadWriteSeparation.java
+++ b/example/src/main/java/io/mycat/example/readWriteSeparation/ReadWriteSeparation.java
@@ -5,11 +5,12 @@ import io.mycat.MycatCore;
 import io.mycat.RootHelper;
 import lombok.SneakyThrows;
 
+import java.net.URISyntaxException;
 import java.nio.file.Paths;
 
 public class ReadWriteSeparation {
     @SneakyThrows
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         String resource = Paths.get( ReadWriteSeparation.class.getResource("").toURI()).toAbsolutePath().toString();
         System.out.println(resource);
         System.setProperty("MYCAT_HOME", resource);

--- a/proxy/src/main/java/io/mycat/proxy/session/MySQLSessionManager.java
+++ b/proxy/src/main/java/io/mycat/proxy/session/MySQLSessionManager.java
@@ -204,7 +204,7 @@ public class MySQLSessionManager implements
                 return;
             }
             //////////////////////////////////////////////////
-            session.setCursorStatementId(-1);
+//            session.setCursorStatementId(-1);
             session.resetPacket();
             session.setIdle(true);
             session.switchNioHandler(IdleHandler.INSTANCE);
@@ -483,7 +483,7 @@ public class MySQLSessionManager implements
             public void onException(Exception exception, Object sender, Object attr) {
                 long now = System.currentTimeMillis();
                 long maxConnectTimeout = key.getMaxConnectTimeout();
-                if (retryCount > maxRetry || startTime + maxConnectTimeout > now) {
+                if (retryCount >= maxRetry || startTime + maxConnectTimeout > now) {
                     callBack.onException(exception, sender, attr);
                 } else {
                     ++retryCount;


### PR DESCRIPTION
1、MySQLSessionManager类中设置游标声明ID
MySQLClientSession.java中
private long cursorStatementId;
可以看到没有setCursorStatementId(int id)方法
此处代码编辑器会显示报错，截图
![image](https://user-images.githubusercontent.com/35326449/78334808-00274b80-75bf-11ea-83a5-6ddf2c96ab99.png)
2、分母为零的处理
同一个类中，490行存在分母为零的情况，截图如下：
![image](https://user-images.githubusercontent.com/35326449/78335060-7f1c8400-75bf-11ea-985c-f1813ac3a3b9.png)
