### PR TITLE
An ArithmeticException will happen when you retry the connection

### DIFF
--- a/proxy/src/main/java/io/mycat/proxy/session/MySQLSessionManager.java
+++ b/proxy/src/main/java/io/mycat/proxy/session/MySQLSessionManager.java
@@ -483,7 +483,7 @@ public class MySQLSessionManager implements
             public void onException(Exception exception, Object sender, Object attr) {
                 long now = System.currentTimeMillis();
                 long maxConnectTimeout = key.getMaxConnectTimeout();
-                if (retryCount > maxRetry || startTime + maxConnectTimeout > now) {
+                if (retryCount >= maxRetry || startTime + maxConnectTimeout > now) { // retryCount==maxRetry时，重试次数已经用完
                     callBack.onException(exception, sender, attr);
                 } else {
                     ++retryCount;


### PR DESCRIPTION
**expected Behavior**
No ArithmeticException thrown.
**Current Behavior**
Avoid the appearance of ArithmeticException.
**Context & Steps to Reproduce**
It's easy to reproduce this issue.For example, you only need to use the shortcut key Ctrl + N in the IDEA editor and enter MySQLSessionManager.java to find it:
`if (retryCount > maxRetry || startTime + maxConnectTimeout > now) { `
         `callBack.onException(exception, sender, attr); `
   ` } else { `
         `++retryCount; `
         `long waitTime = (maxConnectTimeout + startTime - now) / maxRetry - retryCount; `
       ` ...`
`}`
You may get it when you retry the connection
`java.lang.ArithmeticException: / by zero`
The reason is that in the else code block, the global variable retryCount of type int is less than or equal to maxRetry.
**Your Environment**
JDK1.8.0_191