### PR TITLE
修改murmur3_32分片key错误拼接

### DIFF
--- a/router/src/main/java/io/mycat/router/mycat1xfunction/PartitionByMurmurHash.java
+++ b/router/src/main/java/io/mycat/router/mycat1xfunction/PartitionByMurmurHash.java
@@ -79,9 +79,9 @@ public class PartitionByMurmurHash extends Mycat1xSingleValueRuleFunction {
 
     hash = Hashing.murmur3_32(seed);//计算一致性哈希的对象
     for (int i = 0; i < count; i++) {//构造一致性哈希环，用TreeMap表示
-      StringBuilder hashName = new StringBuilder("SHARD-").append(i);
+      String prefix = "SHARD-" + i + "-NODE-";
       for (int n = 0, shard = virtualBucketTimes * getWeight(weightMap, i); n < shard; n++) {
-        bucketMap.put(hash.hashUnencodedChars(hashName.append("-NODE-").append(n)).asInt(), i);
+        bucketMap.put(hash.hashUnencodedChars(prefix + n).asInt(), i);
       }
     }
   }


### PR DESCRIPTION
MyCat1中一直存在一个错误使用StringBuilder问题，导致计算Bucket Map的Hash Key不断加大，不符合分配愿意图。该修改影响兼容性（分片算法不一致，会导致分配算法不一致下的数据访问问题）

另外，请注意：Google的HashFunction函数实现的hashUnencodedChars函数（Java)与文档描述的C++版本代码也存在问题，如果跨平台实现Murmur一致性Hash实现数据访问，需要二选一。