### PR TITLE
Could io.mycat:config:1.22-release drop off redundant dependencies?

### DIFF
--- a/config/pom.xml
+++ b/config/pom.xml
@@ -31,6 +31,16 @@
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>4.7.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-stdlib-common</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jetbrains</groupId>
+                    <artifactId>annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>
@@ -42,12 +52,6 @@
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
             <version>1.2.79</version>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/uk.com.robust-it/cloning -->
-        <dependency>
-            <groupId>uk.com.robust-it</groupId>
-            <artifactId>cloning</artifactId>
-            <version>1.9.12</version>
         </dependency>
         <dependency>
             <groupId>mysql</groupId>
@@ -70,6 +74,11 @@
                     <artifactId>jconsole</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.objenesis</groupId>
+            <artifactId>objenesis</artifactId>
+            <version>3.0.1</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/78527112/167557209-db6b88ba-1cf0-4331-b346-87f0593809e0.png)

Hi! I found the pom file of project **_io.mycat:config:1.22-release_** introduced **_18_** dependencies. However, among them, **_3_** libraries (**_16%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.3.70:compile
uk.com.robust-it:cloning:jar:1.9.12:compile
org.jetbrains:annotations:jar:13.0:compile
## Outdated dependencies
uk.com.robust-it:cloning:1.9.12 (**_1631_** days without maintenance)
org.jetbrains:annotations:13.0 (**_3511_** days without maintenance)

---


Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, As such, I suggest a refactoring operation for **_io.mycat:config:1.22-release_**’s pom file.

As shown in the figure, it is noteworthy that, libraries **_org.objenesis:objenesis::3.0.1:compile_** are invoked by the projects. When we remove the redundant dependency **_uk.com.robust-it:cloning::1.9.12:compile_**, the above **_org.objenesis:objenesis::3.0.1:compile_** should be declared as direct dependencies. The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_io.mycat:config:1.22-release_**’s maven tests.

Best regards